### PR TITLE
Change the status to be more obvious

### DIFF
--- a/modules/product/src/Entity/CommerceProduct.php
+++ b/modules/product/src/Entity/CommerceProduct.php
@@ -271,8 +271,8 @@ class CommerceProduct extends ContentEntityBase implements CommerceProductInterf
     // @todo there should be a way to set the default value from here but I
     // haven't figured out how yet.
     $fields['status'] = FieldDefinition::create('list_boolean')
-      ->setLabel(t('Status'))
-      ->setDescription(t('A boolean indicating whether the product is active.'))
+      ->setLabel(t('Active'))
+      ->setDescription(t('Disabled products cannot be added to shopping carts and may be hidden in administrative product lists.'))
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE)
       ->setSettings(array(


### PR DESCRIPTION
:notebook: 

![image](https://cloud.githubusercontent.com/assets/1440242/3485244/65879a1c-03cd-11e4-8d02-48833f025722.png)

With this patch:

![image](https://cloud.githubusercontent.com/assets/1440242/3485247/91206cb2-03cd-11e4-8b4a-f025f3572ce8.png)
