### PR TITLE
Use newly introduced Path extension for generating urls, date service renamed to date formatter

### DIFF
--- a/modules/order/src/Controller/CommerceOrderListBuilder.php
+++ b/modules/order/src/Controller/CommerceOrderListBuilder.php
@@ -7,7 +7,7 @@ namespace Drupal\commerce_order\Controller;
 
 use Drupal\commerce_order\Entity\CommerceOrderType;
 use Drupal\Component\Utility\String;
-use Drupal\Core\Datetime\Date;
+use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
 use Drupal\Core\Entity\EntityStorageInterface;
@@ -22,9 +22,9 @@ class CommerceOrderListBuilder extends EntityListBuilder {
   /**
    * The date service.
    *
-   * @var \Drupal\Core\Datetime\Date
+   * @var \Drupal\Core\Datetime\DateFormatter
    */
-  protected $dateService;
+  protected $date_formatter;
 
   /**
    * Constructs a new CommerceOrderListBuilder object.
@@ -33,13 +33,13 @@ class CommerceOrderListBuilder extends EntityListBuilder {
    *   The entity type definition.
    * @param \Drupal\Core\Entity\EntityStorageInterface $storage
    *   The entity storage class.
-   * @param \Drupal\Core\Datetime\Date $date_service
+   * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
    *   The date service.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, Date $date_service) {
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, DateFormatter $date_formatter) {
     parent::__construct($entity_type, $storage);
 
-    $this->dateService = $date_service;
+    $this->date_formatter = $date_formatter;
   }
 
   /**
@@ -49,7 +49,7 @@ class CommerceOrderListBuilder extends EntityListBuilder {
     return new static(
       $entity_type,
       $container->get('entity.manager')->getStorage($entity_type->id()),
-      $container->get('date')
+      $container->get('date.formatter')
     );
   }
 
@@ -106,8 +106,8 @@ class CommerceOrderListBuilder extends EntityListBuilder {
         ),
       ),
       'status' => $entity->getStatus(),
-      'created' => $this->dateService->format($entity->getCreatedTime(), 'short'),
-      'changed' => $this->dateService->format($entity->getChangedTime(), 'short'),
+      'created' => $this->date_formatter->format($entity->getCreatedTime(), 'short'),
+      'changed' => $this->date_formatter->format($entity->getChangedTime(), 'short'),
     );
     return $row + parent::buildRow($entity);
   }

--- a/modules/order/src/Form/CommerceOrderTypeForm.php
+++ b/modules/order/src/Form/CommerceOrderTypeForm.php
@@ -101,7 +101,7 @@ class CommerceOrderTypeForm extends EntityForm {
       drupal_set_message($this->t('Saved the %label order type.', array(
         '%label' => $order_type->label(),
       )));
-      $form_state->setRedirect('entity.commerce_order_type.list'),
+      $form_state->setRedirect('entity.commerce_order_type.list');
     }
     catch (\Exception $e) {
       watchdog_exception('commerce_order', $e);

--- a/modules/order/templates/commerce-order-add-list.html.twig
+++ b/modules/order/templates/commerce-order-add-list.html.twig
@@ -23,7 +23,7 @@
     </dl>
 {% else %}
     <p>
-        {% set create_order_type = url('admin/commerce/config/order-types/add') %}
+        {% set create_order_type = path('commerce.order_type_add') %}
         {% trans %}
         You have not created any order types yet. Go to the <a href="{{ create_order_type }}">order type creation page</a> to add a new order type.
         {% endtrans %}

--- a/modules/product/src/Controller/CommerceProductController.php
+++ b/modules/product/src/Controller/CommerceProductController.php
@@ -41,7 +41,7 @@ class CommerceProductController extends ControllerBase implements ContainerInjec
    *
    * @param \Drupal\Core\Database\Connection $database
    *   The database connection.
-   * @param \Drupal\Core\Datetime\DateFormatter $date
+   * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
    *   The date service.
    */
   public function __construct(Connection $database, DateFormatter $date_formatter) {
@@ -98,7 +98,7 @@ class CommerceProductController extends ControllerBase implements ContainerInjec
   /**
    * Provides the product add form.
    *
-   * @param \Drupal\commerce\CommerceProductTypeInterface $commerce_product_type
+   * @param \Drupal\commerce_product\CommerceProductTypeInterface $commerce_product_type
    *   The product type entity for the product.
    *
    * @return array
@@ -121,7 +121,7 @@ class CommerceProductController extends ControllerBase implements ContainerInjec
   /**
    * The _title_callback for the commerce_product.add route.
    *
-   * @param \Drupal\commerce\CommerceProductTypeInterface $commerce_product_type
+   * @param \Drupal\commerce_product\CommerceProductTypeInterface $commerce_product_type
    *   The current product.
    *
    * @return string

--- a/modules/product/templates/commerce-product-add-list.html.twig
+++ b/modules/product/templates/commerce-product-add-list.html.twig
@@ -22,7 +22,7 @@
   </dl>
 {% else %}
   <p>
-    {% set create_product_type = url('admin/commerce/products/types/add') %}
+    {% set create_product_type = path('commerce.product_type_add') %}
     {% trans %}
       You have not created any product types yet. Go to the <a href="{{ create_product_type }}">product type creation page</a> to add a new product type.
     {% endtrans %}

--- a/templates/commerce-store-add-list.html.twig
+++ b/templates/commerce-store-add-list.html.twig
@@ -22,7 +22,7 @@
   </dl>
 {% else %}
   <p>
-    {% set create_store_type = url('admin/commerce/config/store/types/add') %}
+    {% set create_store_type = path('commerce.store_type_add') %}
     {% trans %}
       You have not created any store types yet. Go to the <a href="{{ create_store_type }}">store type creation page</a> to add a new store type.
     {% endtrans %}


### PR DESCRIPTION
- Use newly introduced Path extension for generating urls https://www.drupal.org/node/2073811
- Date service renamed to date formatter (Was already done for the product module)
- Missing semicolon in CommerceOrderTypeForm
