### PR TITLE
Fix the add routes when there are no types defined

### DIFF
--- a/modules/order/templates/commerce-order-add-list.html.twig
+++ b/modules/order/templates/commerce-order-add-list.html.twig
@@ -23,7 +23,7 @@
     </dl>
 {% else %}
     <p>
-        {% set create_order_type = path('commerce.order_type_add') %}
+        {% set create_order_type = path('entity.commerce_order_type.add') %}
         {% trans %}
         You have not created any order types yet. Go to the <a href="{{ create_order_type }}">order type creation page</a> to add a new order type.
         {% endtrans %}

--- a/modules/product/templates/commerce-product-add-list.html.twig
+++ b/modules/product/templates/commerce-product-add-list.html.twig
@@ -22,7 +22,7 @@
   </dl>
 {% else %}
   <p>
-    {% set create_product_type = path('commerce.product_type_add') %}
+    {% set create_product_type = path('commerce_product.product_type_add') %}
     {% trans %}
       You have not created any product types yet. Go to the <a href="{{ create_product_type }}">product type creation page</a> to add a new product type.
     {% endtrans %}


### PR DESCRIPTION
Routes are not correct and produce an error when there are no types defined for products and orders, store entity is fine.
