### PR TITLE
Add Commerce Product SKU validation.

### DIFF
--- a/modules/product/src/Entity/CommerceProduct.php
+++ b/modules/product/src/Entity/CommerceProduct.php
@@ -244,6 +244,7 @@ class CommerceProduct extends ContentEntityBase implements CommerceProductInterf
       ->setLabel(t('SKU'))
       ->setDescription(t('The unique, human-readable identifier for a product.'))
       ->setRequired(TRUE)
+      ->addConstraint('ProductSku', array())
       ->setTranslatable(TRUE)
       ->setRevisionable(TRUE)
       ->setDisplayOptions('view', array(

--- a/modules/product/src/Plugin/Validation/Constraint/ProductSkuConstraint.php
+++ b/modules/product/src/Plugin/Validation/Constraint/ProductSkuConstraint.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_product\Plugin\Validation\Constraint\ProductSkuConstraint.
+ */
+
+namespace Drupal\commerce_product\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Supports validating comment author names.
+ *
+ * @Plugin(
+ *   id = "ProductSku",
+ *   label = @Translation("The SKU of the product.", context = "Validation")
+ * )
+ */
+class ProductSkuConstraint extends Constraint {
+
+  public $message = '%sku belongs to a product.';
+
+}

--- a/modules/product/src/Plugin/Validation/Constraint/ProductSkuConstraintValidator.php
+++ b/modules/product/src/Plugin/Validation/Constraint/ProductSkuConstraintValidator.php
@@ -15,17 +15,21 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class ProductSkuConstraintValidator extends ConstraintValidator {
 
-    /**
-     * {@inheritdoc}
-     */
-    public function validate($field_item, Constraint $constraint) {
-        $sku= $field_item->value;
-        if (isset($sku) && $sku !== '') {
-            $commerce_products = \Drupal::entityManager()->getStorage('commerce_product')->loadByProperties(array('sku' => $sku));
-            if (!empty($commerce_products)) {
-                $this->context->addViolation($constraint->message, array('%sku' => $sku));
-            }
-        }
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($field_item, Constraint $constraint) {
+    $sku = $field_item->value;
+    if (isset($sku) && $sku !== '') {
+      $sku_exists = (bool) \Drupal::entityQuery('commerce_product')
+        ->condition("sku", $sku)
+        ->range(0, 1)
+        ->count()
+        ->execute();
+      if ($sku_exists) {
+        $this->context->addViolation($constraint->message, array('%sku' => $sku));
+      }
     }
+  }
 
 }

--- a/modules/product/src/Plugin/Validation/Constraint/ProductSkuConstraintValidator.php
+++ b/modules/product/src/Plugin/Validation/Constraint/ProductSkuConstraintValidator.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\comment\Plugin\Validation\Constraint\ProductSkuConstraintValidator.
+ */
+
+namespace Drupal\commerce_product\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the ProductSku constraint.
+ */
+class ProductSkuConstraintValidator extends ConstraintValidator {
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($field_item, Constraint $constraint) {
+        $sku= $field_item->value;
+        if (isset($sku) && $sku !== '') {
+            $commerce_products = \Drupal::entityManager()->getStorage('commerce_product')->loadByProperties(array('sku' => $sku));
+            if (!empty($commerce_products)) {
+                $this->context->addViolation($constraint->message, array('%sku' => $sku));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Is it better to do something like (which CommentNameConstraintValidator does):          

```
$commerce_product = \Drupal::entityManager()->getStorage('commerce_product')->loadByProperties(array('sku' => $sku));
```

Or:

```
$sku_exists = (bool) \Drupal::entityQuery('commerce_product')
->condition("sku", $sku)
->range(0, 1)
->count()
->execute();
```

Which UserUniqueValidator uses?

Also, I'm getting a really weird form error:

```
Notice: Undefined index: in Drupal\Core\Field\WidgetBase->flagErrors() (line 427 of core/lib/Drupal/Core/Field/WidgetBase.php).
Drupal\Core\Field\WidgetBase->flagErrors(Object, Object, Array, Object)
Drupal\entity\Entity\EntityFormDisplay->validateFormValues(Object, Array, Object)
Drupal\Core\Entity\ContentEntityForm->validate(Array, Object)
call_user_func_array(Array, Array)
Drupal\Core\Form\FormValidator->executeValidateHandlers(Array, Object)
Drupal\Core\Form\FormValidator->doValidateForm(Array, Object, 'product_commerce_product_add_form')
Drupal\Core\Form\FormValidator->validateForm('product_commerce_product_add_form', Array, Object)
Drupal\Core\Form\FormBuilder->processForm('product_commerce_product_add_form', Array, Object)
Drupal\Core\Form\FormBuilder->buildForm(Object, Object)
Drupal\Core\Entity\EntityFormBuilder->getForm(Object, 'add')
Drupal\commerce_product\Controller\CommerceProductController->add(Object)
call_user_func_array(Array, Array)
Drupal\Core\Controller\HtmlPageController->getContentResult(Object, '\Drupal\commerce_product\Controller\CommerceProductController::add')
Drupal\Core\Controller\HtmlPageController->content(Object, '\Drupal\commerce_product\Controller\CommerceProductController::add')
call_user_func_array(Array, Array)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1)
Drupal\Core\DrupalKernel->handle(Object)
Notice: Undefined index: in Drupal\Core\Field\WidgetBase->flagErrors() (line 428 of core/lib/Drupal/Core/Field/WidgetBase.php).
Drupal\Core\Field\WidgetBase->flagErrors(Object, Object, Array, Object)
Drupal\entity\Entity\EntityFormDisplay->validateFormValues(Object, Array, Object)
Drupal\Core\Entity\ContentEntityForm->validate(Array, Object)
call_user_func_array(Array, Array)
Drupal\Core\Form\FormValidator->executeValidateHandlers(Array, Object)
Drupal\Core\Form\FormValidator->doValidateForm(Array, Object, 'product_commerce_product_add_form')
Drupal\Core\Form\FormValidator->validateForm('product_commerce_product_add_form', Array, Object)
Drupal\Core\Form\FormBuilder->processForm('product_commerce_product_add_form', Array, Object)
Drupal\Core\Form\FormBuilder->buildForm(Object, Object)
Drupal\Core\Entity\EntityFormBuilder->getForm(Object, 'add')
Drupal\commerce_product\Controller\CommerceProductController->add(Object)
call_user_func_array(Array, Array)
Drupal\Core\Controller\HtmlPageController->getContentResult(Object, '\Drupal\commerce_product\Controller\CommerceProductController::add')
Drupal\Core\Controller\HtmlPageController->content(Object, '\Drupal\commerce_product\Controller\CommerceProductController::add')
call_user_func_array(Array, Array)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1)
Drupal\Core\DrupalKernel->handle(Object)
Recoverable fatal error: Argument 1 passed to Drupal\Core\Field\WidgetBase::errorElement() must be of the type array, null given, called in /home/josh/www/commerce/core/lib/Drupal/Core/Field/WidgetBase.php on line 432 and defined in Drupal\Core\Field\WidgetBase->errorElement() (line 491 of core/lib/Drupal/Core/Field/WidgetBase.php).
Drupal\Core\Field\WidgetBase->errorElement(NULL, Object, Array, Object)
Drupal\Core\Field\WidgetBase->flagErrors(Object, Object, Array, Object)
Drupal\entity\Entity\EntityFormDisplay->validateFormValues(Object, Array, Object)
Drupal\Core\Entity\ContentEntityForm->validate(Array, Object)
call_user_func_array(Array, Array)
Drupal\Core\Form\FormValidator->executeValidateHandlers(Array, Object)
Drupal\Core\Form\FormValidator->doValidateForm(Array, Object, 'product_commerce_product_add_form')
Drupal\Core\Form\FormValidator->validateForm('product_commerce_product_add_form', Array, Object)
Drupal\Core\Form\FormBuilder->processForm('product_commerce_product_add_form', Array, Object)
Drupal\Core\Form\FormBuilder->buildForm(Object, Object)
Drupal\Core\Entity\EntityFormBuilder->getForm(Object, 'add')
Drupal\commerce_product\Controller\CommerceProductController->add(Object)
call_user_func_array(Array, Array)
Drupal\Core\Controller\HtmlPageController->getContentResult(Object, '\Drupal\commerce_product\Controller\CommerceProductController::add')
Drupal\Core\Controller\HtmlPageController->content(Object, '\Drupal\commerce_product\Controller\CommerceProductController::add')
call_user_func_array(Array, Array)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1)
Drupal\Core\DrupalKernel->handle(Object)
```

In WidgetBase.php:

```
          // Otherwise, pass errors by delta to the corresponding sub-element.
          else {
            $original_delta = $field_state['original_deltas'][$delta];
            $delta_element = $element[$original_delta];
          }
```

Original delta is blank.
