### PR TITLE
As the text module is used in commerce product it will need to be enabled

### DIFF
--- a/modules/product/commerce_product.info.yml
+++ b/modules/product/commerce_product.info.yml
@@ -5,3 +5,4 @@ package: Commerce
 core: 8.x
 dependencies:
   - commerce
+  - text


### PR DESCRIPTION
As other Drupal 8 modules also rely on this, this will also need to be included as it is used in commerce_product.
