### PR TITLE
Updates Commerce entity annotation per #2309187

### DIFF
--- a/modules/order/src/Entity/CommerceOrder.php
+++ b/modules/order/src/Entity/CommerceOrder.php
@@ -39,11 +39,11 @@ use Drupal\user\UserInterface;
  *     "bundle" = "type"
  *   },
  *   links = {
- *     "admin-form" = "entity.commerce_order.admin_form",
  *     "edit-form" = "entity.commerce_order.edit_form",
  *     "delete-form" = "entity.commerce_order.delete_form"
  *   },
- *   bundle_entity_type = "commerce_order_type"
+ *   bundle_entity_type = "commerce_order_type",
+ *   field_ui_base_route = "entity.commerce_order.admin_form",
  * )
  */
 class CommerceOrder extends ContentEntityBase implements CommerceOrderInterface {

--- a/modules/payment/src/Entity/CommercePaymentInfo.php
+++ b/modules/payment/src/Entity/CommercePaymentInfo.php
@@ -37,10 +37,10 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *     "uuid" = "uuid"
  *   },
  *   bundle_entity_type = "commerce_payment_info_type",
+ *   field_ui_base_route = "entity.commerce_payment_info.admin_form",
  *   permission_granularity = "bundle",
  *   admin_permission = "administer commerce_payment_info entities",
  *   links = {
- *     "admin-form" = "entity.commerce_payment_info.admin_form",
  *     "edit-form" = "entity.commerce_payment_info.edit_form",
  *     "delete-form" = "entity.commerce_payment_info.delete_form"
  *   },

--- a/modules/product/src/Entity/CommerceProduct.php
+++ b/modules/product/src/Entity/CommerceProduct.php
@@ -48,9 +48,9 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *   links = {
  *     "edit-form" = "commerce_product.edit",
  *     "delete-form" = "commerce_product.delete",
- *     "admin-form" = "commerce_product.product_type_edit"
  *   },
- *   bundle_entity_type = "commerce_product_type"
+ *   bundle_entity_type = "commerce_product_type",
+ *   field_ui_base_route = "commerce_product.product_type_edit",
  * )
  */
 class CommerceProduct extends ContentEntityBase implements CommerceProductInterface {

--- a/src/Entity/CommerceStore.php
+++ b/src/Entity/CommerceStore.php
@@ -43,9 +43,9 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *   links = {
  *     "edit-form" = "commerce.store_edit",
  *     "delete-form" = "commerce.store_delete",
- *     "admin-form" = "commerce.store_type_edit"
  *   },
- *   bundle_entity_type = "commerce_store_type"
+ *   bundle_entity_type = "commerce_store_type",
+ *   field_ui_base_route = "commerce.store_type_edit",
  * )
  */
 class CommerceStore extends ContentEntityBase implements CommerceStoreInterface {


### PR DESCRIPTION
Entity annotation changed in core to clear up "Fix double-link-entry between Entity and Entity Type classes." PR updates this.
