### PR TITLE
Issue #2323775 Define data_tables for our translatable entities

### DIFF
--- a/modules/product/src/Entity/CommerceProduct.php
+++ b/modules/product/src/Entity/CommerceProduct.php
@@ -34,6 +34,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *   fieldable = TRUE,
  *   translatable = TRUE,
  *   base_table = "commerce_product",
+ *   data_table = "commerce_product_field_data",
  *   revision_table = "commerce_product_revision",
  *   revision_data_table = "commerce_product_field_revision",
  *   uri_callback = "commerce_product_uri",
@@ -189,7 +190,7 @@ class CommerceProduct extends ContentEntityBase implements CommerceProductInterf
       ->setReadOnly(TRUE);
 
     // Language
-    $fields['language'] = BaseFieldDefinition::create('language')
+    $fields['langcode'] = BaseFieldDefinition::create('language')
       ->setLabel(t('Language code'))
       ->setDescription(t('The language code of product.'))
       ->setRevisionable(TRUE);

--- a/src/Entity/CommerceStore.php
+++ b/src/Entity/CommerceStore.php
@@ -30,6 +30,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *     "translation" = "Drupal\content_translation\ContentTranslationHandler"
  *   },
  *   base_table = "commerce_store",
+ *   data_table = "commerce_store_field_data",
  *   admin_permission = "administer commerce_store entities",
  *   fieldable = TRUE,
  *   translatable = TRUE,


### PR DESCRIPTION
- Rename the language field on the product entity from language to langcode
- Define a data_table for our translatable entities, this is enforced now because of https://www.drupal.org/node/2322097
