### PR TITLE
CommerceProductListBuilder buildRow $langcode is not defined.

### DIFF
--- a/modules/product/src/CommerceProductListBuilder.php
+++ b/modules/product/src/CommerceProductListBuilder.php
@@ -33,6 +33,7 @@ class CommerceProductListBuilder extends EntityListBuilder {
 
     $uri = $entity->urlInfo();
     $options = $uri->getOptions();
+    $langcode = $entity->language()->id;
     $options += ($langcode != LanguageInterface::LANGCODE_NOT_SPECIFIED && isset($languages[$langcode]) ? array('language' => $languages[$langcode]) : array());
     $uri->setOptions($options);
     $row['title']['data'] = array(


### PR DESCRIPTION
Borrowed from NodeListBuilder.php in Core: Added `$langcode = $entity->language()->id;` for https://www.drupal.org/node/2320509
