### PR TITLE
Add a WYSIWYG-enabled body field to products

### DIFF
--- a/modules/product/commerce_product.module
+++ b/modules/product/commerce_product.module
@@ -12,6 +12,8 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\commerce_product\CommerceProductInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldInstanceConfig;
 
 /**
  * Implements hook_entity_operation().
@@ -99,4 +101,55 @@ function commerce_product_theme() {
       'template' => 'commerce-product-add-list',
     ),
   );
+}
+
+/**
+ * Adds the default body field to a product type.
+ *
+ * @param string $product_type_id
+ *   Id of the Commerce Product type.
+ * @param string $label
+ *   (optional) The label for the body instance. Defaults to 'Body'
+ *
+ * @return array
+ *   Body field instance.
+ */
+function commerce_product_add_body_field($product_type_id, $label = 'Body') {
+  // Add or remove the body field, as needed.
+  $field_storage = FieldStorageConfig::loadByName('commerce_product', 'body');
+  $instance = FieldInstanceConfig::loadByName('commerce_product', $product_type_id, 'body');
+  if (empty($field_storage)) {
+    $field_storage = entity_create('field_storage_config', array(
+      'name' => 'body',
+      'entity_type' => 'commerce_product',
+      'type' => 'text_with_summary',
+    ));
+    $field_storage->save();
+  }
+  if (empty($instance)) {
+    $instance = entity_create('field_instance_config', array(
+      'field_storage' => $field_storage,
+      'bundle' => $product_type_id,
+      'label' => $label,
+      'settings' => array('display_summary' => FALSE),
+    ));
+    $instance->save();
+
+    // Assign widget settings for the 'default' form mode.
+    entity_get_form_display('commerce_product', $product_type_id, 'default')
+      ->setComponent('body', array(
+        'type' => 'text_textarea_with_summary',
+      ))
+      ->save();
+
+    // Assign display settings for 'default' view mode.
+    entity_get_display('commerce_product', $product_type_id, 'default')
+      ->setComponent('body', array(
+        'label' => 'hidden',
+        'type' => 'text_default',
+      ))
+      ->save();
+  }
+
+  return $instance;
 }

--- a/modules/product/src/CommerceProductInterface.php
+++ b/modules/product/src/CommerceProductInterface.php
@@ -68,24 +68,6 @@ interface CommerceProductInterface extends EntityInterface {
    */
   public function setStatus($status);
 
- /**
-   * Get the description of this product.
-   *
-   * @return string
-   *   The product description
-   */
-  public function getDescription();
-
-  /**
-   * Set the description of this product
-   *
-   * @param string $description
-   *   The product description
-   *
-   * @return \Drupal\commerce_product\CommerceProductInterface
-   */
-  public function setDescription($description);
-
   /**
    * Returns the product creation timestamp.
    *

--- a/modules/product/src/Entity/CommerceProduct.php
+++ b/modules/product/src/Entity/CommerceProduct.php
@@ -103,21 +103,6 @@ class CommerceProduct extends ContentEntityBase implements CommerceProductInterf
   /**
    * {@inheritdoc}
    */
-  public function getDescription() {
-    return $this->get('description')->value;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setDescription($description) {
-    $this->set('description', $description);
-    return $this;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getCreatedTime() {
     return $this->get('created')->value;
   }
@@ -217,27 +202,6 @@ class CommerceProduct extends ContentEntityBase implements CommerceProductInterf
         'weight' => -5,
       ))
       ->setDisplayConfigurable('form', TRUE);
-
-    // Description
-    $fields['description'] = BaseFieldDefinition::create('text_long')
-      ->setLabel(t('Description'))
-      ->setDescription(t('The description of this product.'))
-      ->setTranslatable(TRUE)
-      ->setRevisionable(TRUE)
-      ->setSettings(array(
-        'default_value' => '',
-      ))
-      ->setDisplayOptions('view', array(
-        'label' => 'hidden',
-        'type' => 'string',
-        'weight' => -3,
-      ))
-      ->setDisplayOptions('form', array(
-        'type' => 'text_textarea',
-        'weight' => -3,
-      ))
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
 
     // SKU
     $fields['sku'] = BaseFieldDefinition::create('string')

--- a/modules/product/src/Entity/CommerceProductType.php
+++ b/modules/product/src/Entity/CommerceProductType.php
@@ -8,6 +8,7 @@
 namespace Drupal\commerce_product\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\commerce_product\CommerceProductTypeInterface;
 
 /**
@@ -69,6 +70,24 @@ class CommerceProductType extends ConfigEntityBundleBase implements CommerceProd
   protected $description;
 
   /**
+   * Indicates whether a body field should be created for this product type.
+   *
+   * This property affects entity creation only. It allows default configuration
+   * of modules and installation profiles to specify whether a Body field should
+   * be created for this bundle.
+   *
+   * @var bool
+   */
+  protected $create_body = TRUE;
+
+  /**
+   * The label to use for the body field upon entity creation.
+   *
+   * @var string
+   */
+  protected $create_body_label = 'Body';
+
+  /**
    * {@inheritdoc}
    */
   public function getDescription() {
@@ -82,5 +101,19 @@ class CommerceProductType extends ConfigEntityBundleBase implements CommerceProd
     $this->description = $description;
     return $this;
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+    parent::postSave($storage, $update);
+
+    // Create a body if the create_body property is true and we're not in
+    // the syncing process.
+    if ($this->get('create_body') && !$this->isSyncing()) {
+      $label = $this->get('create_body_label');
+      commerce_product_add_body_field($this->id, $label);
+    }
+   }
 
 }


### PR DESCRIPTION
Adds the WYSIWYG body field. However, I wasn't sure if the description field was to stay on the Commerce Product Type.
