### PR TITLE
Enable revision for Commerce product entity

### DIFF
--- a/modules/product/commerce_product.libraries.yml
+++ b/modules/product/commerce_product.libraries.yml
@@ -1,0 +1,8 @@
+drupal.commerce_product:
+  version: VERSION
+  js:
+    js/commerce_product.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupal.form

--- a/modules/product/config/schema/commerce_product.schema.yml
+++ b/modules/product/config/schema/commerce_product.schema.yml
@@ -8,6 +8,9 @@ commerce_product.commerce_product_type.*:
     label:
         type: label
         label: 'Label'
+    revision:
+      type: integer
+      label: 'Create new revision'
     description:
       type: text
       label: 'Description'

--- a/modules/product/js/commerce_product.js
+++ b/modules/product/js/commerce_product.js
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Defines Javascript behaviors for the commerce_product module.
+ */
+
+(function ($) {
+
+  "use strict";
+
+  Drupal.behaviors.commerceProductDetailsSummaries = {
+    attach: function (context) {
+      var $context = $(context);
+      $context.find('.product-form-revision-information').drupalSetSummary(function (context) {
+        var $context = $(context);
+        var revisionCheckbox = $context.find('.form-item-revision input');
+
+        // Return 'New revision' if the 'Create new revision' checkbox is checked,
+        // or if the checkbox doesn't exist, but the revision log does. For users
+        // without the "Administer content" permission the checkbox won't appear,
+        // but the revision log will if the content type is set to auto-revision.
+        if (revisionCheckbox.is(':checked') || (!revisionCheckbox.length && $context.find('.form-item-revision-log textarea').length)) {
+          return Drupal.t('New revision');
+        }
+
+        return Drupal.t('No revision');
+      });
+    }
+  };
+
+})(jQuery);

--- a/modules/product/src/CommerceProductInterface.php
+++ b/modules/product/src/CommerceProductInterface.php
@@ -125,4 +125,23 @@ interface CommerceProductInterface extends EntityInterface {
    */
   public function setUid($uid);
 
+  /**
+   * Returns the product revision log message.
+   *
+   * @return string
+   *   The revision log message.
+   */
+  public function getRevisionLog();
+
+  /**
+   * Sets the product revision log message.
+   *
+   * @param string $revision_log
+   *   The revision log message.
+   *
+   * @return \Drupal\commerce_product\CommerceProductInterface
+   *   The class instance that this method is called on.
+   */
+  public function setRevisionLog($revision_log);
+
 }

--- a/modules/product/src/Entity/CommerceProductType.php
+++ b/modules/product/src/Entity/CommerceProductType.php
@@ -70,6 +70,13 @@ class CommerceProductType extends ConfigEntityBundleBase implements CommerceProd
   protected $description;
 
   /**
+   * The default revision setting for products of this type.
+   *
+   * @var bool
+   */
+  public $revision;
+
+  /**
    * Indicates whether a body field should be created for this product type.
    *
    * This property affects entity creation only. It allows default configuration

--- a/modules/product/src/Form/CommerceProductForm.php
+++ b/modules/product/src/Form/CommerceProductForm.php
@@ -16,18 +16,87 @@ use Drupal\Core\Form\FormStateInterface;
 class CommerceProductForm extends ContentEntityForm {
 
   /**
+   * Overrides \Drupal\Core\Entity\EntityForm::prepareEntity().
+   *
+   * Prepares the product object.
+   *
+   * Fills in a few default values, and then invokes hook_commerce_product_prepare()
+   * on all modules.
+   */
+  protected function prepareEntity() {
+    $product = $this->entity;
+    // Set up default values, if required.
+    $product_type = entity_load('commerce_product_type', $product->bundle());
+    if (!$product->isNew()) {
+      $product->setRevisionLog(NULL);
+    }
+    // Always use the default revision setting.
+    $product->setNewRevision($product_type->revision);
+  }
+
+  /**
    * Overrides Drupal\Core\Entity\EntityFormController::form().
    */
   public function form(array $form, FormStateInterface $form_state) {
     /* @var $entity \Drupal\commerce_product\Entity\CommerceProduct */
     $form = parent::form($form, $form_state);
     $product = $this->entity;
+    $account = $this->currentUser();
 
     // There appears to be no way to set default value for checkboxes in the
     // field definitions yet ...
     if ($product->isNew()) {
       $form['status']['widget']['#default_value'] = 1;
     }
+
+    $form['advanced'] = array(
+      '#type' => 'vertical_tabs',
+      '#weight' => 99,
+    );
+
+    // Add a log field if the "Create new revision" option is checked, or if the
+    // current user has the ability to check that option.
+    $form['revision_information'] = array(
+      '#type' => 'details',
+      '#title' => $this->t('Revision information'),
+      // Open by default when "Create new revision" is checked.
+      '#open' => $product->isNewRevision(),
+      '#group' => 'advanced',
+      '#attributes' => array(
+        'class' => array('product-form-revision-information'),
+      ),
+      '#attached' => array(
+        'library' => array('commerce_product/drupal.commerce_product'),
+      ),
+      '#weight' => 20,
+      '#access' => $product->isNewRevision() || $account->hasPermission('administer commerce_product entities'),
+    );
+
+    $form['revision_information']['revision'] = array(
+      '#type' => 'checkbox',
+      '#title' => $this->t('Create new revision'),
+      '#default_value' => $product->isNewRevision(),
+      '#access' => $account->hasPermission('administer commerce_product entities'),
+    );
+
+    // Check the revision log checkbox when the log textarea is filled in.
+    // This must not happen if "Create new revision" is enabled by default,
+    // since the state would auto-disable the checkbox otherwise.
+    if (!$product->isNewRevision()) {
+      $form['revision_information']['revision']['#states'] = array(
+        'checked' => array(
+          'textarea[name="revision_log"]' => array('empty' => FALSE),
+        ),
+      );
+    }
+
+    $form['revision_information']['revision_log'] = array(
+      '#type' => 'textarea',
+      '#title' => $this->t('Revision log message'),
+      '#rows' => 4,
+      '#default_value' => $product->getRevisionLog(),
+      '#description' => $this->t('Briefly describe the changes you have made.'),
+    );
 
     return $form;
   }
@@ -38,7 +107,14 @@ class CommerceProductForm extends ContentEntityForm {
   public function submit(array $form, FormStateInterface $form_state) {
     // Build the entity object from the submitted values.
     $entity = parent::submit($form, $form_state);
+
     $form_state->setRedirect('entity.commerce_product.list');
+
+    // Save as a new revision if requested to do so.
+    if (!$form_state->isValueEmpty('revision')) {
+      $entity->setNewRevision();
+    }
+
     return $entity;
   }
 

--- a/modules/product/src/Form/CommerceProductTypeForm.php
+++ b/modules/product/src/Form/CommerceProductTypeForm.php
@@ -42,6 +42,13 @@ class CommerceProductTypeForm extends EntityForm {
       '#default_value' => $product_type->getDescription(),
     );
 
+    $form['revision'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Create new revision'),
+      '#default_value' => $product_type->revision,
+      '#description' => t('Create a new revision by default for this product type.')
+    );
+
     return $form;
   }
 


### PR DESCRIPTION
You'll see the Form API checks user access to administer commerce_product entities. This is how Core checks if a user can do a revision or not, following same pattern.

Note: Couldn't sleep so I squeezed this in before vacation, which means I may not be able to reply/fix any comments until Monday.
