### PR TITLE
Minor fixes, Set default value for product status

### DIFF
--- a/modules/price/src/Form/CommerceCurrencyForm.php
+++ b/modules/price/src/Form/CommerceCurrencyForm.php
@@ -86,7 +86,7 @@ class CommerceCurrencyForm extends EntityForm {
       '#type' => 'textfield',
       '#title' => $this->t('Fraction digits'),
       '#maxlength' => 255,
-      '#default_value' => $currency->getDecimals(),
+      '#default_value' => $currency->getFractionDigits(),
       '#description' => $this->t('The number of digits after the decimal sign.'),
       '#required' => TRUE,
     );

--- a/modules/product/src/Entity/CommerceProduct.php
+++ b/modules/product/src/Entity/CommerceProduct.php
@@ -251,11 +251,10 @@ class CommerceProduct extends ContentEntityBase implements CommerceProductInterf
       ->setRevisionable(TRUE);
 
     // Status
-    // @todo there should be a way to set the default value from here but I
-    // haven't figured out how yet.
     $fields['status'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Active'))
       ->setDescription(t('Disabled products cannot be added to shopping carts and may be hidden in administrative product lists.'))
+      ->setDefaultValue(TRUE)
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE)
       ->setSettings(array(

--- a/modules/product/src/Form/CommerceProductDeleteForm.php
+++ b/modules/product/src/Form/CommerceProductDeleteForm.php
@@ -44,7 +44,7 @@ class CommerceProductDeleteForm extends ContentEntityConfirmFormBase {
     $this->entity->delete();
     drupal_set_message($this->t('Product %label has been deleted.', array('%label' => $this->entity->label())));
     $this->logger('commerce_product')->notice('Product %name has been deleted.', array('%label' => $this->entity->label()));
-    $form_state->setRedirect($this->getCancelUrl());
+    $form_state->setRedirectUrl($this->getCancelUrl());
   }
 
 }

--- a/modules/product/src/Form/CommerceProductForm.php
+++ b/modules/product/src/Form/CommerceProductForm.php
@@ -43,10 +43,8 @@ class CommerceProductForm extends ContentEntityForm {
     $product = $this->entity;
     $account = $this->currentUser();
 
-    // There appears to be no way to set default value for checkboxes in the
-    // field definitions yet ...
     if ($product->isNew()) {
-      $form['status']['widget']['#default_value'] = 1;
+      $form['status']['widget'];
     }
 
     $form['advanced'] = array(

--- a/src/Form/CommerceStoreDeleteForm.php
+++ b/src/Form/CommerceStoreDeleteForm.php
@@ -50,7 +50,7 @@ class CommerceStoreDeleteForm extends ContentEntityConfirmFormBase {
       drupal_set_message($this->t('Store %label could not be deleted.', array('%label' => $this->entity->label()), 'error'));
       $this->logger('commerce')->error($e);
     }
-    $form_state->setRedirect($this->getCancelUrl());
+    $form_state->setRedirectUrl($this->getCancelUrl());
   }
 
 }


### PR DESCRIPTION
- Fixes two redirects on the Store and Product delete form
- The fractionDigits field was using a non-existing method for its default value, changed it to getFractionDigits()
- Sets a default value for the status checkbox on the product form
