### PR TITLE
Issue #2327283 Create translations for a currency

### DIFF
--- a/modules/price/commerce_price.install
+++ b/modules/price/commerce_price.install
@@ -1,28 +1,18 @@
 <?php
 
-use CommerceGuys\Intl\Currency\DefaultCurrencyManager;
-
 /**
  * Implements hook_install().
  *
  * Import the default currencies from the library.
  */
 function commerce_price_install() {
+  /** @var \Drupal\commerce_price\CurrencyImporterInterface $currency_importer */
+  $currency_importer = \Drupal::service('commerce_price.currency_importer');
   // A list of currencies to import and enable by default.
   $preloaded_currencies = array('USD', 'EUR', 'GBP');
 
-  $default_manager = new DefaultCurrencyManager;
-  foreach ($preloaded_currencies as $currency) {
-    $default_currency = $default_manager->get($currency);
-    $values = array(
-      'currencyCode' => $default_currency->getCurrencyCode(),
-      'name' => $default_currency->getName(),
-      'numericCode' => $default_currency->getNumericCode(),
-      'symbol' => $default_currency->getSymbol(),
-      'fractionDigits' => $default_currency->getFractionDigits(),
-      'status' => TRUE,
-    );
-    $entity = entity_create('commerce_currency', $values);
+  foreach ($preloaded_currencies as $currency_code) {
+    $entity = $currency_importer->importCurrency($currency_code);
     $entity->save();
   }
 }

--- a/modules/price/commerce_price.module
+++ b/modules/price/commerce_price.module
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\language\Entity\ConfigurableLanguage;
 
 /**
  * Implements hook_entity_operation().
@@ -24,4 +25,14 @@ function commerce_price_entity_operation(EntityInterface $entity) {
   }
 
   return $operations;
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert() for 'configurable_language'.
+ **/
+function commerce_price_configurable_language_insert(ConfigurableLanguage $language) {
+  $currency_importer = \Drupal::service('commerce_price.currency_importer');
+
+  $currencies = \Drupal\commerce_price\Entity\CommerceCurrency::loadMultiple();
+  $currency_importer->importCurrencyTranslations($currencies, array($language));
 }

--- a/modules/price/commerce_price.services.yml
+++ b/modules/price/commerce_price.services.yml
@@ -1,4 +1,4 @@
 services:
-  commerce_currency_importer:
+  commerce_price.currency_importer:
     class: Drupal\commerce_price\CurrencyImporter
-    arguments: ['@entity.manager', '@language_manager']
+    arguments: ['@language_manager']

--- a/modules/price/config/schema/commerce_price.schema.yml
+++ b/modules/price/config/schema/commerce_price.schema.yml
@@ -15,6 +15,7 @@ commerce_price.commerce_currency.*:
     symbol:
       type: string
       label: 'Symbol'
+      translatable: true
     fractionDigits:
       type: integer
       label: 'Fraction digits'

--- a/modules/price/src/CurrencyImporterInterface.php
+++ b/modules/price/src/CurrencyImporterInterface.php
@@ -25,9 +25,21 @@ interface CurrencyImporterInterface {
    *
    * @param string $currency_code
    *   The currency code.
-   * @return \Drupal\commerce_price\Entity\CommerceCurrency|FALSE
-   *   The new Currency or False if the currency is already imported.
+   * @return \Drupal\commerce_price\Entity\CommerceCurrency|bool
+   *   The new currency or false if the currency is already imported.
    */
   public function importCurrency($currency_code);
+
+  /**
+   * Imports translations for the currency entity.
+   *
+   * @param \Drupal\commerce_price\Entity\CommerceCurrency[] $currencies
+   *   Array of currencies to import translations for.
+   * @param \Drupal\language\ConfigurableLanguageManagerInterface[] $languages
+   *   Array of languages to import.
+   * @return \Drupal\commerce_price\Entity\CommerceCurrency|bool
+   *  The currency entity or false if the site is not multilingual.
+   */
+  public function importCurrencyTranslations($currencies = array(), $languages = array());
 
 }

--- a/modules/price/src/Form/CommerceCurrencyImporterForm.php
+++ b/modules/price/src/Form/CommerceCurrencyImporterForm.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\commerce_price\Form;
 
+use CommerceGuys\Intl\Currency\CurrencyInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use SebastianBergmann\Exporter\Exception;
@@ -22,7 +23,7 @@ class CommerceCurrencyImporterForm extends FormBase {
   protected $currencyImporter;
 
   public function __construct() {
-    $this->currencyImporter = \Drupal::service('commerce_currency_importer');
+    $this->currencyImporter = \Drupal::service('commerce_price.currency_importer');
   }
 
   /**
@@ -51,14 +52,12 @@ class CommerceCurrencyImporterForm extends FormBase {
         '#button_type' => 'primary',
         '#name' => 'import',
         '#value' => $this->t('Import'),
-        '#validate' => array('::validateForm'),
         '#submit' => array('::submitForm'),
       );
       $form['actions']['import_new'] = array(
         '#type' => 'submit',
         '#name' => 'import_and_new',
         '#value' => $this->t('Import and new'),
-        '#validate' => array('::validateForm'),
         '#submit' => array('::submitForm'),
       );
     }
@@ -67,14 +66,14 @@ class CommerceCurrencyImporterForm extends FormBase {
   }
 
   /**
-   * Returns an options list of all currencies.
+   * Returns an options list for currencies.
    *
-   * @param $currencies
+   * @param CurrencyInterface[] $currencies
    *   An array of currencies.
    * @return array
    *   The list of options for a select widget.
    */
-  public function getCurrencyOptions($currencies) {
+  public function getCurrencyOptions(array $currencies) {
     $options = array();
     foreach ($currencies as $currency_code => $currency) {
       $options[$currency_code] = $currency->getName();


### PR DESCRIPTION
- Refactor commerce_price.install to use the currency importer service.
- Rename the importer service.
- The Symbol field is translatable as well.
- Create translations for currency entities when a new language is added or when the user adds
  a new currency.
