### PR TITLE
 Fixes crash enabling the price module, use the entity manager, code style fixes

### DIFF
--- a/modules/price/commerce_price.module
+++ b/modules/price/commerce_price.module
@@ -2,6 +2,7 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\Core\Language\LanguageInterface;
 
 /**
  * Implements hook_entity_operation().
@@ -29,10 +30,13 @@ function commerce_price_entity_operation(EntityInterface $entity) {
 
 /**
  * Implements hook_ENTITY_TYPE_insert() for 'configurable_language'.
- **/
+ */
 function commerce_price_configurable_language_insert(ConfigurableLanguage $language) {
-  $currency_importer = \Drupal::service('commerce_price.currency_importer');
+  // Ignore 'und' and 'zxx'.
+  if (!($language->getId() == LanguageInterface::LANGCODE_NOT_SPECIFIED || $language->getId() == LanguageInterface::LANGCODE_NOT_APPLICABLE)) {
+    $currency_importer = \Drupal::service('commerce_price.currency_importer');
 
-  $currencies = \Drupal\commerce_price\Entity\CommerceCurrency::loadMultiple();
-  $currency_importer->importCurrencyTranslations($currencies, array($language));
+    $currencies = \Drupal\commerce_price\Entity\CommerceCurrency::loadMultiple();
+    $currency_importer->importCurrencyTranslations($currencies, array($language));
+  }
 }

--- a/modules/price/commerce_price.services.yml
+++ b/modules/price/commerce_price.services.yml
@@ -1,4 +1,4 @@
 services:
   commerce_price.currency_importer:
     class: Drupal\commerce_price\CurrencyImporter
-    arguments: ['@language_manager']
+    arguments: ['@entity.manager', '@language_manager']

--- a/modules/price/src/CurrencyImporterInterface.php
+++ b/modules/price/src/CurrencyImporterInterface.php
@@ -13,20 +13,29 @@ namespace Drupal\commerce_price;
 interface CurrencyImporterInterface {
 
   /**
+   * Default language to fallback to.
+   */
+  const FALLBACK_LANGUAGE = 'en';
+
+  /**
    * Returns all importable currencies.
    *
-   * @return Array
-   *   Array of importable currencies.
+   * @param string $fallback
+   *   The fallback language code.
+   *
+   * @return array
+   *    Array of importable currencies.
    */
-  public function getImportableCurrencies();
+  public function getImportableCurrencies($fallback = self::FALLBACK_LANGUAGE);
 
   /**
    * Creates a new currency object for the given currency code.
    *
    * @param string $currency_code
    *   The currency code.
-   * @return \Drupal\commerce_price\Entity\CommerceCurrency|bool
-   *   The new currency or false if the currency is already imported.
+   *
+   * @return \Drupal\commerce_price\Entity\CommerceCurrency | bool
+   *    The new currency or false if the currency is already imported.
    */
   public function importCurrency($currency_code);
 
@@ -37,8 +46,9 @@ interface CurrencyImporterInterface {
    *   Array of currencies to import translations for.
    * @param \Drupal\language\ConfigurableLanguageManagerInterface[] $languages
    *   Array of languages to import.
-   * @return \Drupal\commerce_price\Entity\CommerceCurrency|bool
-   *  The currency entity or false if the site is not multilingual.
+   *
+   * @return \Drupal\commerce_price\Entity\CommerceCurrency | bool
+   *   The currency entity or false if the site is not multilingual.
    */
   public function importCurrencyTranslations($currencies = array(), $languages = array());
 

--- a/modules/price/src/Form/CommerceCurrencyImporterForm.php
+++ b/modules/price/src/Form/CommerceCurrencyImporterForm.php
@@ -18,10 +18,15 @@ use SebastianBergmann\Exporter\Exception;
 class CommerceCurrencyImporterForm extends FormBase {
 
   /**
+   * The currency importer.
+   *
    * @var \Drupal\commerce_price\CurrencyImporterInterface
    */
   protected $currencyImporter;
 
+  /**
+   * Constructs a new CommerceCurrencyImporterForm.
+   */
   public function __construct() {
     $this->currencyImporter = \Drupal::service('commerce_price.currency_importer');
   }
@@ -70,6 +75,7 @@ class CommerceCurrencyImporterForm extends FormBase {
    *
    * @param CurrencyInterface[] $currencies
    *   An array of currencies.
+   *
    * @return array
    *   The list of options for a select widget.
    */
@@ -103,7 +109,8 @@ class CommerceCurrencyImporterForm extends FormBase {
       else {
         $form_state->setRedirect('entity.commerce_currency.list');
       }
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       drupal_set_message(
         $this->t(
           'The %label currency was not imported.',


### PR DESCRIPTION
- Fixes crash enabling the price module without having the language module enabled.
- Use the entity manager instead of static methods on the currency entity.
- Minor Code Standard fixes.
