### PR TITLE
Adjust forms to reflect core changes, small cleanup.

### DIFF
--- a/modules/order/src/Form/CommerceOrderDeleteForm.php
+++ b/modules/order/src/Form/CommerceOrderDeleteForm.php
@@ -50,7 +50,7 @@ class CommerceOrderDeleteForm extends ContentEntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array $form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     try {
       $this->entity->delete();
       $order_type_storage = $this->entityManager->getStorage('commerce_order_type');

--- a/modules/order/src/Form/CommerceOrderTypeDeleteForm.php
+++ b/modules/order/src/Form/CommerceOrderTypeDeleteForm.php
@@ -29,7 +29,7 @@ class CommerceOrderTypeDeleteForm extends EntityConfirmFormBase {
    * Constructs a new CommerceOrderTypeDeleteForm object.
    *
    * @param \Drupal\Core\Entity\Query\QueryFactory $query_factory
-   * The entity query object.
+   *   The entity query object.
    */
   public function __construct(QueryFactory $query_factory) {
     $this->queryFactory = $query_factory;
@@ -85,7 +85,7 @@ class CommerceOrderTypeDeleteForm extends EntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array $form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     try {
       $this->entity->delete();
       $form_state->setRedirectUrl($this->getCancelUrl());

--- a/modules/payment/src/Form/CommercePaymentInfoDeleteForm.php
+++ b/modules/payment/src/Form/CommercePaymentInfoDeleteForm.php
@@ -50,18 +50,18 @@ class CommercePaymentInfoDeleteForm extends ContentEntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array $form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     try {
       $this->entity->delete();
       $payment_info_type_storage = $this->entityManager->getStorage('commerce_payment_info_type');
       $payment_info_type = $payment_info_type_storage->load($this->entity->bundle())->label();
       $form_state->setRedirectUrl($this->getCancelUrl());
       drupal_set_message($this->t('@type %payment_info_label has been deleted.', array('@type' => $payment_info_type, '%payment_info_label' => $this->entity->label())));
-      watchdog('commerce_payment', '@type: deleted %payment_info_label.', array('@type' => $this->entity->bundle(), '%payment_info_label' => $this->entity->label()));
+      $this->logger('commerce_payment')->notice('commerce_payment', '@type: deleted %payment_info_label.', array('@type' => $this->entity->bundle(), '%payment_info_label' => $this->entity->label()));
     }
     catch (\Exception $e) {
       drupal_set_message($this->t('The payment information %payment_info_label could not be deleted.', array('%payment_info_label' => $this->entity->label())), 'error');
-      watchdog_exception('commerce_payment', $e);
+      $this->logger('commerce_payment')->error($e);
     }
   }
 

--- a/modules/payment/src/Form/CommercePaymentInfoTypeDeleteForm.php
+++ b/modules/payment/src/Form/CommercePaymentInfoTypeDeleteForm.php
@@ -40,7 +40,7 @@ class CommercePaymentInfoTypeDeleteForm extends EntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array $form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     try {
       $this->entity->delete();
       $form_state->setRedirectUrl($this->getCancelUrl());
@@ -48,7 +48,7 @@ class CommercePaymentInfoTypeDeleteForm extends EntityConfirmFormBase {
     }
     catch (\Exception $e) {
       drupal_set_message($this->t('Payment information type %payment_info_type_label could not be deleted.', array('%payment_info_type_label' => $this->entity->label())), 'error');
-      watchdog_exception('commerce_payment', $e);
+      $this->logger('commerce_payment')->error($e);
     }
   }
 

--- a/modules/price/src/Form/CommerceCurrencyDeleteForm.php
+++ b/modules/price/src/Form/CommerceCurrencyDeleteForm.php
@@ -40,7 +40,7 @@ class CommerceCurrencyDeleteForm extends EntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array $form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     try {
       $this->entity->delete();
       $form_state->setRedirectUrl($this->getCancelUrl());

--- a/modules/product/src/Form/CommerceProductDeleteForm.php
+++ b/modules/product/src/Form/CommerceProductDeleteForm.php
@@ -40,7 +40,7 @@ class CommerceProductDeleteForm extends ContentEntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array $form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
     drupal_set_message($this->t('Product %label has been deleted.', array('%label' => $this->entity->label())));
     $this->logger('commerce_product')->notice('Product %name has been deleted.', array('%label' => $this->entity->label()));

--- a/modules/product/src/Form/CommerceProductTypeDeleteForm.php
+++ b/modules/product/src/Form/CommerceProductTypeDeleteForm.php
@@ -29,7 +29,7 @@ class CommerceProductTypeDeleteForm extends EntityConfirmFormBase {
    * Constructs a new CommerceProductTypeDeleteForm object.
    *
    * @param \Drupal\Core\Entity\Query\QueryFactory $query_factory
-   * The entity query object.
+   *    The entity query object.
    */
   public function __construct(QueryFactory $query_factory) {
     $this->queryFactory = $query_factory;
@@ -87,7 +87,7 @@ class CommerceProductTypeDeleteForm extends EntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array $form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
     drupal_set_message($this->t('Store type %label has been deleted.', array('%label' => $this->entity->label())));
     $form_state->setRedirectUrl($this->getCancelUrl());

--- a/modules/product/src/Form/CommerceProductTypeForm.php
+++ b/modules/product/src/Form/CommerceProductTypeForm.php
@@ -59,13 +59,13 @@ class CommerceProductTypeForm extends EntityForm {
     try {
       $this->entity->save();
       drupal_set_message($this->t('The product type %product_type_label has been successfully saved.', array('%product_type_label' => $this->entity->label())));
+      $form_state->setRedirect('entity.commerce_product_type.list');
     }
     catch (\Exception $e) {
       drupal_set_message($this->t('The product type %product_type_label could not be saved.', array('%product_type_label' => $this->entity->label())), 'error');
       $this->logger('commerce_product')->error($e);
+      $form_state->setRebuild();
     }
-
-    $form_state->setRedirect('entity.commerce_product_type.list');
   }
 
 }

--- a/src/Form/CommerceStoreDeleteForm.php
+++ b/src/Form/CommerceStoreDeleteForm.php
@@ -40,7 +40,7 @@ class CommerceStoreDeleteForm extends ContentEntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array $form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     try {
       $this->entity->delete();
       drupal_set_message($this->t('Store %label has been deleted.', array('%label' => $this->entity->label())));

--- a/src/Form/CommerceStoreTypeDeleteForm.php
+++ b/src/Form/CommerceStoreTypeDeleteForm.php
@@ -85,7 +85,7 @@ class CommerceStoreTypeDeleteForm extends EntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array $form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     try {
       $this->entity->delete();
       drupal_set_message($this->t('Store type %label has been deleted.', array('%label' => $this->entity->label())));


### PR DESCRIPTION
- Changed submit() to submitForm() on entity delete forms.
- Replaces all occurrences of watchdog() with the logger.
