### PR TITLE
Adding hook_requirements() to commerce_price.install 

### DIFF
--- a/modules/price/commerce_price.install
+++ b/modules/price/commerce_price.install
@@ -16,3 +16,34 @@ function commerce_price_install() {
     $entity->save();
   }
 }
+
+/**
+ * Implements hook_requirements().
+ *
+ * Check that the Commerce Guys' Libraries have been installed.
+ */
+function commerce_price_requirements($phase) {
+  $requirements = array();
+
+  if ($phase == 'install') {
+    if (\Drupal::moduleHandler()->moduleExists('composer_manager')) {
+      /* @var $packages Drupal\composer_manager\ComposerPackages */
+      $packages = \Drupal::service('composer_manager.packages');
+
+      if (!array_key_exists('commerceguys/intl', $packages->getInstalled())){
+        $requirements['commerce_price_library'] = array(
+          'description' => t("Commerce Price requires the Commerce Guys' International Library, run !command on the command line", array('!command' => 'drush composer install')),
+          'severity' => REQUIREMENT_ERROR,
+        );
+      }
+    }
+    else {
+      $requirements['commerce_price_composer_manager'] = array(
+        'description' => t("Commerce Price requires the Commerce Guys' International Library"),
+        'severity' => REQUIREMENT_ERROR,
+      );
+    }
+  }
+
+  return $requirements;
+}

--- a/modules/price/commerce_price.install
+++ b/modules/price/commerce_price.install
@@ -26,20 +26,12 @@ function commerce_price_requirements($phase) {
   $requirements = array();
 
   if ($phase == 'install') {
-    if (\Drupal::moduleHandler()->moduleExists('composer_manager')) {
-      /* @var $packages Drupal\composer_manager\ComposerPackages */
-      $packages = \Drupal::service('composer_manager.packages');
+    /* @var $packages Drupal\composer_manager\ComposerPackages */
+    $packages = \Drupal::service('composer_manager.packages');
 
-      if (!array_key_exists('commerceguys/intl', $packages->getInstalled())){
-        $requirements['commerce_price_library'] = array(
-          'description' => t("Commerce Price requires the Commerce Guys' International Library, run !command on the command line", array('!command' => 'drush composer install')),
-          'severity' => REQUIREMENT_ERROR,
-        );
-      }
-    }
-    else {
-      $requirements['commerce_price_composer_manager'] = array(
-        'description' => t("Commerce Price requires the Commerce Guys' International Library"),
+    if (!array_key_exists('commerceguys/intl', $packages->getInstalled())){
+      $requirements['commerce_price_library'] = array(
+        'description' => t("Commerce Price requires the Commerce Guys' International Library, run !command on the command line", array('!command' => 'drush composer install')),
         'severity' => REQUIREMENT_ERROR,
       );
     }


### PR DESCRIPTION
Adding hook_requirements() to commerce_price.install as uses the commerceguys/intl library which needs to be installed via composer first.
