### PR TITLE
 Issue #2333375 Format Price field using NumberFormatter. 

### DIFF
--- a/modules/price/src/Plugin/Field/FieldFormatter/PriceFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PriceFormatter.php
@@ -7,8 +7,14 @@
 
 namespace Drupal\commerce_price\Plugin\Field\FieldFormatter;
 
+use CommerceGuys\Intl\Formatter\NumberFormatter;
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the commerce price formatter.
@@ -21,19 +27,119 @@ use Drupal\Core\Field\FormatterBase;
  *   }
  * )
  */
-class PriceFormatter extends FormatterBase {
+class PriceFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The currency storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $currencyStorage;
+
+  /**
+   * The number format storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $numberFormatterStorage;
+
+  /**
+   * Constructs a PriceFormatter object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings settings.
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   *   The entity manager.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityManagerInterface $entity_manager) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+
+    $this->currencyStorage = $entity_manager->getStorage('commerce_currency');
+    $this->numberFormatterStorage = $entity_manager->getStorage('commerce_number_format');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('entity.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return array(
+      'show_currency_code' => FALSE,
+    ) + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $elements, FormStateInterface $form_state) {
+    $elements['show_currency_code'] = array(
+      '#type' => 'checkbox',
+      '#title' => $this->t('Display the currency code instead of the currency symbol.'),
+      '#default_value' => $this->getSetting('show_currency_code'),
+    );
+
+    return $elements;
+  }
 
   /**
    * {@inheritdoc}
    */
   public function viewElements(FieldItemListInterface $items) {
     $elements = array();
+    $format = $this->getNumberFormat();
+    $display_mode = $this->getSetting('show_currency_code') ? NumberFormatter::CURRENCY_DISPLAY_CODE : NumberFormatter::CURRENCY_DISPLAY_SYMBOL;
+
+    $number_formatter = new NumberFormatter($format, NumberFormatter::CURRENCY);
+    $number_formatter->setCurrencyDisplay($display_mode);
 
     foreach ($items as $delta => $item) {
-      $elements[$delta] = array('#markup' => $item->amount . ' ' . $item->currency_code);
+      $currency = $this->currencyStorage->load($item->currency_code);
+      $elements[$delta] = array('#markup' => $number_formatter->formatCurrency($item->amount, $currency));
     }
 
     return $elements;
+  }
+
+  /**
+   * Returns the number format for the current language.
+   *
+   * @return \CommerceGuys\Intl\NumberFormat\NumberFormat|\CommerceGuys\Intl\NumberFormat\NumberFormatInterface
+   *    The number format.
+   */
+  protected function getNumberFormat() {
+    $language = \Drupal::languageManager()->getCurrentLanguage();
+
+    // @TODO a fallback number format provided us or configured by the user.
+    $number_format = $this->numberFormatterStorage->load($language->getId());
+
+    return $number_format;
   }
 
 }

--- a/modules/price/src/Plugin/Field/FieldType/Price.php
+++ b/modules/price/src/Plugin/Field/FieldType/Price.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\commerce_price\Plugin\Field\FieldType;
 
+use CommerceGuys\Intl\Formatter\NumberFormatterInterface;
 use Drupal\Core\Field\FieldItemBase;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\TypedData\DataDefinition;


### PR DESCRIPTION
Format the price field using the Intl library.

I still have one question.. what to do when the number format for the current locale isn't available? We could fallback to 'en' but then we need to make sure that the english number format is installed when the price module is enabled and make sure it can't be removed.
