### PR TITLE
Fix error payment installation and change the fields to be plain strings

### DIFF
--- a/modules/payment/config/install/field.field.commerce_payment_info.card.card_name.yml
+++ b/modules/payment/config/install/field.field.commerce_payment_info.card.card_name.yml
@@ -14,6 +14,5 @@ required: true
 translatable: false
 default_value: {  }
 default_value_function: ''
-settings:
-  text_processing: 0
-field_type: text
+settings: {  }
+field_type: string

--- a/modules/payment/config/install/field.field.commerce_payment_info.card.card_number.yml
+++ b/modules/payment/config/install/field.field.commerce_payment_info.card.card_number.yml
@@ -14,6 +14,5 @@ required: true
 translatable: false
 default_value: {  }
 default_value_function: ''
-settings:
-  text_processing: 0
-field_type: text
+settings: {  }
+field_type: string

--- a/modules/payment/config/install/field.field.commerce_payment_info.card.card_type.yml
+++ b/modules/payment/config/install/field.field.commerce_payment_info.card.card_type.yml
@@ -1,19 +1,19 @@
 id: commerce_payment_info.card.card_type
+label: Card type
+field_name: card_type
 entity_type: commerce_payment_info
 bundle: card
-field_name: card_type
-label: Card type
 description: 'The card type.'
-required: true
-translatable: true
-default_value: {  }
-default_value_function: ''
-settings:
-  text_processing: 0
-status: true
 langcode: und
-field_type: text
+status: true
 dependencies:
   entity:
     - commerce_payment.commerce_payment_info_type.card
     - field.storage.commerce_payment_info.card_type
+required: true
+translatable: false
+default_value: {  }
+default_value_function: ''
+settings: {  }
+field_type: string
+

--- a/modules/payment/config/install/field.storage.commerce_payment_info.card_exp_month.yml
+++ b/modules/payment/config/install/field.storage.commerce_payment_info.card_exp_month.yml
@@ -1,5 +1,5 @@
 id: commerce_payment_info.card_exp_month
-name: card_exp_month
+field_name: card_exp_month
 entity_type: commerce_payment_info
 type: integer
 langcode: und

--- a/modules/payment/config/install/field.storage.commerce_payment_info.card_exp_year.yml
+++ b/modules/payment/config/install/field.storage.commerce_payment_info.card_exp_year.yml
@@ -1,5 +1,5 @@
 id: commerce_payment_info.card_exp_year
-name: card_exp_year
+field_name: card_exp_year
 entity_type: commerce_payment_info
 type: integer
 langcode: und

--- a/modules/payment/config/install/field.storage.commerce_payment_info.card_name.yml
+++ b/modules/payment/config/install/field.storage.commerce_payment_info.card_name.yml
@@ -1,16 +1,15 @@
 id: commerce_payment_info.card_name
 field_name: card_name
 entity_type: commerce_payment_info
-type: text
+type: string
 langcode: en
 status: true
 dependencies:
   module:
     - commerce_payment
-    - text
 settings:
   max_length: 255
-module: text
+module: core
 locked: false
 cardinality: 1
 translatable: true

--- a/modules/payment/config/install/field.storage.commerce_payment_info.card_name.yml
+++ b/modules/payment/config/install/field.storage.commerce_payment_info.card_name.yml
@@ -1,5 +1,5 @@
 id: commerce_payment_info.card_name
-name: card_name
+field_name: card_name
 entity_type: commerce_payment_info
 type: text
 langcode: en

--- a/modules/payment/config/install/field.storage.commerce_payment_info.card_number.yml
+++ b/modules/payment/config/install/field.storage.commerce_payment_info.card_number.yml
@@ -1,16 +1,15 @@
 id: commerce_payment_info.card_number
 field_name: card_number
 entity_type: commerce_payment_info
-type: text
+type: string
 langcode: en
 status: true
 dependencies:
   module:
     - commerce_payment
-    - text
 settings:
   max_length: 4
-module: text
+module: core
 locked: false
 cardinality: 1
 translatable: true

--- a/modules/payment/config/install/field.storage.commerce_payment_info.card_number.yml
+++ b/modules/payment/config/install/field.storage.commerce_payment_info.card_number.yml
@@ -1,5 +1,5 @@
 id: commerce_payment_info.card_number
-name: card_number
+field_name: card_number
 entity_type: commerce_payment_info
 type: text
 langcode: en

--- a/modules/payment/config/install/field.storage.commerce_payment_info.card_type.yml
+++ b/modules/payment/config/install/field.storage.commerce_payment_info.card_type.yml
@@ -1,10 +1,10 @@
 id: commerce_payment_info.card_type
 field_name: card_type
 entity_type: commerce_payment_info
-type: text
+type: string
 settings:
   max_length: 255
-module: text
+module: core
 locked: false
 cardinality: 1
 translatable: true
@@ -13,4 +13,3 @@ langcode: und
 dependencies:
   module:
     - commerce_payment
-    - text

--- a/modules/payment/config/install/field.storage.commerce_payment_info.card_type.yml
+++ b/modules/payment/config/install/field.storage.commerce_payment_info.card_type.yml
@@ -1,5 +1,5 @@
 id: commerce_payment_info.card_type
-name: card_type
+field_name: card_type
 entity_type: commerce_payment_info
 type: text
 settings:

--- a/modules/payment/config/install/field.storage.commerce_payment_transaction.commerce_price.yml
+++ b/modules/payment/config/install/field.storage.commerce_payment_transaction.commerce_price.yml
@@ -1,5 +1,5 @@
 id: commerce_payment_transaction.commerce_price
-name: commerce_price
+field_name: commerce_price
 entity_type: commerce_payment_transaction
 type: price
 settings: {  }


### PR DESCRIPTION
Text processing option was removed on the text field type and a new string field type was added: https://www.drupal.org/node/2329465
