### PR TITLE
Fix travis tests as per discussion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: php
+cache:
+  bundler: true
+  directories:
+    - $HOME/tmp/drush
+    - $HOME/.bundle
+  apt: true
 
 php:
   - 5.4
@@ -20,23 +26,46 @@ install:
   # Make sure we don't fail when checking out projects
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 
+  # LAMP package installation (mysql is already started)
+  - sudo apt-get update
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
+
+  # enable php-fpm, travis does not support any other method with php and apache
+  - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  - sudo a2enmod rewrite actions fastcgi alias
+  - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+
+  # Make sure the apache root is in our wanted directory
+  - echo "$(curl -fsSL https://gist.githubusercontent.com/nickveenhof/11386315/raw/b8abaf9304fe12b5cc7752d39c29c1edae8ac2e6/gistfile1.txt)" | sed -e "s,PATH,$TRAVIS_BUILD_DIR/../drupal,g" | sudo tee /etc/apache2/sites-available/default > /dev/null
+
   # Disable sendmail.
   - echo sendmail_path=`which true` >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
+  # Forward the errors to the syslog so we can print them
+  - echo "error_log=syslog" >> `php --ini | grep "Loaded Configuration" | awk '{print $4}'`
+
 
   # Build Codebase.
   - TESTDIR=$(pwd)
   - cd ..
-  - git clone --branch 8.0.x http://git.drupal.org/project/drupal.git drupal
+  - git clone --branch 8.0.x --depth 1 http://git.drupal.org/project/drupal.git drupal
   - git clone --branch 8.x-1.x http://git.drupal.org/project/devel.git drupal/modules/devel
   - git clone --branch 8.x-1.x http://git.drupal.org/project/composer_manager.git drupal/modules/composer_manager
   - cd drupal
   - wget https://www.drupal.org/files/issues/run_tests_sh_should-2189345-30.patch
   - git apply -v -p1 < run_tests_sh_should-2189345-30.patch
 
+  # Restart apache and test it
+  - sudo service apache2 restart
+  - curl -v "http://localhost"
+
 before_script:
   - ln -s $TESTDIR modules/commerce
   # Mysql might time out for long tests, increase the wait timeout.
   - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
+  # Update drupal core
+  - git pull origin 8.0.x
   - drush si --db-url=mysql://root:@127.0.0.1/drupal --account-name=admin --account-pass=admin --site-mail=admin@example.com --site-name="Commerce" --yes
   - drush en -y devel composer_manager simpletest commerce
   - echo "require 'sites/all/vendor/autoload.php';" | sudo tee -a sites/default/settings.php
@@ -44,12 +73,24 @@ before_script:
   - composer install
   - cd ../../../../
   - drush pm-enable commerce_product commerce_order --yes
-  - drush pm-uninstall dblog --yes
-  - drush runserver localhost:8888 &
-  - until netstat -an 2>/dev/null | grep '8888.*LISTEN'; do true; done
 
 script:
-  - php ./core/scripts/run-tests.sh --php `which php` --die-on-fail --url http://localhost:8888 --color "commerce"
+  # Run the tests
+  - php core/scripts/run-tests.sh --verbose --color --concurrency 4 --php `which php` --url http://localhost "commerce" | tee /tmp/test.txt; TEST_EXIT=${PIPESTATUS[0]}; echo $TEST_EXIT
+  # Check if we had fails in the run-tests.sh script
+  # Exit with the inverted value, because if there are no fails found, it will exit with 1 and for us that\
+  # is a good thing so invert it to 0. Travis has some issues with the exclamation mark in front so we have to fiddle a
+  # bit.
+  # Also make the grep case insensitive and fail on run-tests.sh regular fails as well on fatal errors.
+  - TEST_OUTPUT=$(! egrep -i "([0-9]+ fails)|(PHP Fatal error)|([0-9]+ exceptions)" /tmp/test.txt > /dev/null)$?
+  - echo $TEST_OUTPUT
+  # if the TEST_EXIT status is 0 AND the TEST_OUTPUT status is also 0 it means we succeeded, in all other cases we
+  # failed.
+  # Re-enable when trying to get CodeSniffer doesn't return a 403 anymore.
+  #- /home/travis/.composer/vendor/bin/phpcs --standard=/home/travis/.composer/vendor/drupal/coder/coder_sniffer/Drupal --extensions=php,inc,test,module,install --ignore=css/ $TRAVIS_BUILD_DIR/../drupal/modules/search_api
+  - php -i | grep 'php.ini'
+  - sudo cat /var/log/apache2/error.log
+
   #  Enable once PHPUnit tests are in Commerce
   #  - cd $TRAVIS_BUILD_DIR/../drupal/core
   #  - ./vendor/bin/phpunit --verbose --debug ../modules/commerce/; TEST_PHPUNIT=$?; echo $TEST_PHPUNIT


### PR DESCRIPTION
- Use cache to speed up apt installation
- Install apache2 due to internal PHP webserver routing issues
- Use 1 level of git to speed up git clone and lower bandwidth for
  drupal.org
