### PR TITLE
Line item Entity

### DIFF
--- a/modules/line_item/commerce_line_item.info.yml
+++ b/modules/line_item/commerce_line_item.info.yml
@@ -1,0 +1,7 @@
+name: Commerce Line Item
+type: module
+description: 'Defines the Line Item entity and associated features.'
+package: Commerce
+core: 8.x
+dependencies:
+  - commerce

--- a/modules/line_item/commerce_line_item.links.action.yml
+++ b/modules/line_item/commerce_line_item.links.action.yml
@@ -1,0 +1,5 @@
+entity.commerce_line_item_type.add_form:
+  route_name: entity.commerce_line_item_type.add_form
+  title: 'Add a new line item type'
+  appears_on:
+    - entity.commerce_line_item_type.list

--- a/modules/line_item/commerce_line_item.links.menu.yml
+++ b/modules/line_item/commerce_line_item.links.menu.yml
@@ -1,0 +1,5 @@
+entity.commerce_line_item_type.list:
+  title: Line item types
+  route_name: entity.commerce_line_item_type.list
+  parent: commerce.configuration
+  description: 'Manage your line item types.'

--- a/modules/line_item/commerce_line_item.links.task.yml
+++ b/modules/line_item/commerce_line_item.links.task.yml
@@ -1,0 +1,10 @@
+entity.commerce_line_item_type.edit_form:
+  route_name: entity.commerce_line_item_type.edit_form
+  base_route: entity.commerce_line_item_type.edit_form
+  title: Edit
+
+entity.commerce_line_item_type.devel:
+  route_name: 'entity.commerce_line_item_type.devel'
+  base_route: 'entity.commerce_line_item_type.edit_form'
+  title: 'Devel'
+  weight: 10

--- a/modules/line_item/commerce_line_item.module
+++ b/modules/line_item/commerce_line_item.module
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Defines the core Commerce line item entity type and API functions to manage
+ * line items and interact with them.
+ */
+

--- a/modules/line_item/commerce_line_item.permissions.yml
+++ b/modules/line_item/commerce_line_item.permissions.yml
@@ -1,0 +1,9 @@
+'administer line items':
+  title: 'Administer line items'
+  description: 'Allows users to administer line items.'
+  'restrict access': TRUE
+
+'administer line item types':
+  title: 'Administer line item types'
+  description: 'Allows users to administer line item types.'
+  'restrict access': TRUE

--- a/modules/line_item/commerce_line_item.routing.yml
+++ b/modules/line_item/commerce_line_item.routing.yml
@@ -1,0 +1,50 @@
+entity.commerce_line_item_type.list:
+  path: '/admin/commerce/config/line-item-types'
+  defaults:
+    _entity_list: 'commerce_line_item_type'
+    _title: 'Line item types'
+  options:
+    _admin_route: TRUE
+  requirements:
+    _permission: 'administer line item types'
+
+entity.commerce_line_item_type.edit_form:
+  path: '/admin/commerce/config/line-item-types/{commerce_line_item_type}/edit'
+  defaults:
+    _entity_form: commerce_line_item_type.edit
+    _title: 'Edit a line item type'
+  options:
+    _admin_route: TRUE
+  requirements:
+   _entity_access: 'commerce_line_item_type.edit'
+
+entity.commerce_line_item_type.add_form:
+  path: '/admin/commerce/config/line-item-types/add'
+  defaults:
+    _entity_form: 'commerce_line_item_type.add'
+    _title: 'Add a new line item type'
+  options:
+    _admin_route: TRUE
+  requirements:
+    _entity_create_access: 'commerce_line_item_type'
+
+entity.commerce_line_item_type.delete_form:
+  path: '/admin/commerce/config/line-item-types/{commerce_line_item_type}/delete'
+  defaults:
+    _entity_form: 'commerce_line_item_type.delete'
+    _title: 'Delete a line item type'
+  options:
+    _admin_route: TRUE
+  requirements:
+    _entity_access: 'commerce_line_item_type.delete'
+
+entity.commerce_line_item_type.devel:
+  path: '/admin/commerce/config/line-item-types/{commerce_line_item_type}/devel'
+  defaults:
+    _controller: '\Drupal\commerce_line_item\Controller\CommerceLineItemDevelController::lineItemTypeLoad'
+    _title: 'Dump an line item type'
+  options:
+    _admin_route: TRUE
+  requirements:
+    _module_dependencies: 'devel'
+    _permission: 'access devel information'

--- a/modules/line_item/config/schema/commerce_line_item.schema.yml
+++ b/modules/line_item/config/schema/commerce_line_item.schema.yml
@@ -1,0 +1,13 @@
+commerce_line_item.commerce_line_item_type.*:
+  type: config_entity
+  label: 'Line item type'
+  mapping:
+    label:
+      type: label
+      label: 'Label'
+    id:
+      type: string
+      label: 'Machine-readable name'
+    description:
+      type: text
+      label: 'Description'

--- a/modules/line_item/src/CommerceLineItemInterface.php
+++ b/modules/line_item/src/CommerceLineItemInterface.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_line_item\CommerceLineItemInterface.
+ */
+
+namespace Drupal\commerce_line_item;
+
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\user\EntityOwnerInterface;
+
+/**
+ * Provides an interface defining a Commerce Line item entity.
+ */
+interface CommerceLineItemInterface extends EntityChangedInterface, EntityInterface, EntityOwnerInterface {
+
+  /**
+   * Returns the line item type.
+   *
+   * @return string
+   *   The line item type.
+   */
+  public function getType();
+
+  /**
+   * Returns the line item status.
+   *
+   * @return string
+   *   The line item status.
+   */
+  public function getStatus();
+
+  /**
+   * Sets the line item status.
+   *
+   * @param string $status
+   *   The line item status.
+   *
+   * @return \Drupal\commerce_line_item\CommerceLineItemInterface
+   *   The called line item entity.
+   */
+  public function setStatus($status);
+
+  /**
+   * Returns the line item creation timestamp.
+   *
+   * @return int
+   *   Creation timestamp of the line item.
+   */
+  public function getCreatedTime();
+
+  /**
+   * Sets the line item creation timestamp.
+   *
+   * @param int $timestamp
+   *   The line item creation timestamp.
+   *
+   * @return \Drupal\commerce_line_item\CommerceLineItemInterface
+   *   The called line item entity.
+   */
+  public function setCreatedTime($timestamp);
+
+  /**
+   * Returns the line item revision creation timestamp.
+   *
+   * @return int
+   *   The UNIX timestamp of when this revision was created.
+   */
+  public function getRevisionCreationTime();
+
+  /**
+   * Sets the line item revision creation timestamp.
+   *
+   * @param int $timestamp
+   *   The UNIX timestamp of when this revision was created.
+   *
+   * @return \Drupal\commerce_line_item\CommerceLineItemInterface
+   *   The called line item entity.
+   */
+  public function setRevisionCreationTime($timestamp);
+
+  /**
+   * Returns the line item revision author.
+   *
+   * @return \Drupal\user\UserInterface
+   *   The user entity for the revision author.
+   */
+  public function getRevisionAuthor();
+
+  /**
+   * Sets the line item revision author.
+   *
+   * @param int $uid
+   *   The user ID of the revision author.
+   *
+   * @return \Drupal\commerce_line_item\CommerceLineItemInterface
+   *   The called line item entity.
+   */
+  public function setRevisionAuthorId($uid);
+
+  /**
+   * Returns the additional data stored in this line item.
+   *
+   * @return array
+   *   An array of additional data.
+   */
+  public function getData();
+
+  /**
+   * Sets random information related to this line item.
+   *
+   * @param array $data
+   *   An array of additional data.
+   *
+   * @return \Drupal\commerce_line_item\CommerceLineItemInterface
+   *   The called line item entity.
+   */
+  public function setData($data);
+
+}

--- a/modules/line_item/src/CommerceLineItemListBuilder.php
+++ b/modules/line_item/src/CommerceLineItemListBuilder.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\commerce_line_item\CommerceLineItemListBuilder.
+ */
+
+namespace Drupal\commerce_line_item;
+
+use Drupal\commerce_line_item\Entity\CommerceLineItemType;
+use Drupal\Component\Utility\String;
+use Drupal\Core\Datetime\DateFormatter;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a list controller for commerce_line_item entity.
+ */
+class CommerceLineItemListBuilder extends EntityListBuilder {
+
+  /**
+   * The date service.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatter
+   */
+  protected $date_formatter;
+
+  /**
+   * Constructs a new CommerceLineItemListBuilder object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
+   *   The entity storage class.
+   * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
+   *   The date service.
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, DateFormatter $date_formatter) {
+    parent::__construct($entity_type, $storage);
+
+    $this->date_formatter = $date_formatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type,
+      $container->get('entity.manager')->getStorage($entity_type->id()),
+      $container->get('date.formatter')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header = array(
+      'line_item_id' => array(
+        'data' => $this->t('Line Item ID'),
+        'class' => array(RESPONSIVE_PRIORITY_LOW),
+      ),
+      'type' => array(
+        'data' => $this->t('Line item type'),
+        'class' => array(RESPONSIVE_PRIORITY_MEDIUM),
+      ),
+      'owner' => array(
+        'data' => $this->t('Owner'),
+        'class' => array(RESPONSIVE_PRIORITY_LOW),
+      ),
+      'status' => $this->t('Status'),
+      'created' => array(
+        'data' => $this->t('Created'),
+        'class' => array(RESPONSIVE_PRIORITY_LOW),
+      ),
+      'updated' => array(
+        'data' => $this->t('Updated'),
+        'class' => array(RESPONSIVE_PRIORITY_LOW),
+      ),
+    );
+    return $header + parent::buildHeader();
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    /* @var $entity \Drupal\commerce_line_item\Entity\CommerceLineItem */
+    $commerce_line_item_type = CommerceLineItemType::load($entity->bundle());
+
+    if (!empty($commerce_line_item_type)) {
+      $type = String::checkPlain($commerce_line_item_type->label());
+    }
+    else {
+      $type = String::checkPlain($entity->bundle());
+    }
+
+    $row = array(
+      'line_item_id' => $entity->id(),
+      'type' => $type,
+      'owner' => array(
+        'data' => array(
+          '#theme' => 'username',
+          '#account' => $entity->getOwner(),
+        ),
+      ),
+      'status' => $entity->getStatus(),
+      'created' => $this->date_formatter->format($entity->getCreatedTime(), 'short'),
+      'changed' => $this->date_formatter->format($entity->getChangedTime(), 'short'),
+    );
+    return $row + parent::buildRow($entity);
+  }
+
+}

--- a/modules/line_item/src/CommerceLineItemTypeInterface.php
+++ b/modules/line_item/src/CommerceLineItemTypeInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_line_item\CommerceLineItemTypeInterface.
+ */
+
+namespace Drupal\commerce_line_item;
+
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+
+/**
+ * Provides an interface defining a commerce line item type entity.
+ */
+interface CommerceLineItemTypeInterface extends ConfigEntityInterface {
+
+  /**
+   * Returns the line item type description.
+   *
+   * @return string
+   *   The line item type description.
+   */
+  public function getDescription();
+
+  /**
+   * Sets the description of the line item type.
+   *
+   * @param string $description
+   *   The new description.
+   *
+   * @return $this
+   */
+  public function setDescription($description);
+
+}

--- a/modules/line_item/src/CommerceLineItemTypeListBuilder.php
+++ b/modules/line_item/src/CommerceLineItemTypeListBuilder.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_line_item\Entity\CommerceLineItemTypeListBuilder.
+ */
+
+namespace Drupal\commerce_line_item;
+
+use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Provides a listing of Line item types.
+ */
+class CommerceLineItemTypeListBuilder extends ConfigEntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['label'] = $this->t('Line item type');
+    $header['id'] = $this->t('Machine name');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    $row['label'] = $this->getLabel($entity);
+    $row['id'] = $entity->id();
+    return $row + parent::buildRow($entity);
+  }
+
+}

--- a/modules/line_item/src/Controller/CommerceLineItemController.php
+++ b/modules/line_item/src/Controller/CommerceLineItemController.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_line_item\Controller\CommerceLineItemController.
+ */
+
+namespace Drupal\commerce_line_item\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\commerce_line_item\CommerceLineItemTypeInterface;
+
+/**
+ * Returns responses for Commerce Line item admin routes.
+ */
+class CommerceLineItemController extends ControllerBase {
+
+  /**
+   * Displays add content links for available line_item types.
+   *
+   * Redirects to admin/commerce/config/line_items/add/{line_item-type} if only one
+   * type is available.
+   *
+   * @return array
+   *   A render array for a list of the line item types that can be added.
+   */
+  public function addPage() {
+    $line_item_types = $this->entityManager()->getStorage('commerce_line_item_type')->loadMultiple();
+    // Filter out the line item types the user doesn't have access to.
+    foreach ($line_item_types as $line_item_type_id => $line_item_type) {
+      if (!$this->entityManager()->getAccessControlHandler('commerce_line_item')->createAccess($line_item_type_id)) {
+        unset($line_item_types[$line_item_type_id]);
+      }
+    }
+
+    if (count($line_item_types) == 1) {
+      $line_item_type = reset($line_item_types);
+      return $this->redirect('entity.commerce_line_item.add_form', array('commerce_line_item_type' => $line_item_type->id()));
+    }
+
+    return array(
+      '#theme' => 'commerce_line_item_add_list',
+      '#types' => $line_item_types,
+    );
+  }
+
+  /**
+   * Provides the line item add form.
+   *
+   * @param \Drupal\commerce_line_item\CommerceLineItemTypeInterface $commerce_line_item_type
+   *   The line_item type entity for the line_item.
+   *
+   * @return array
+   *   An line_item add form.
+   */
+  public function add(CommerceLineItemTypeInterface $commerce_line_item_type) {
+    $line_item = $this->entityManager()->getStorage('commerce_line_item')->create(array(
+      'type' => $commerce_line_item_type->id(),
+    ));
+    $form = $this->entityFormBuilder()->getForm($line_item, 'add');
+
+    return $form;
+  }
+
+  /**
+   * The title_callback for the entity.commerce_line_item.add_form route.
+   *
+   * @param \Drupal\commerce_line_item\CommerceLineItemTypeInterface $commerce_line_item_type
+   *   The current line item type.
+   *
+   * @return string
+   *   The page title.
+   */
+  public function addPageTitle(CommerceLineItemTypeInterface $commerce_line_item_type) {
+    return $this->t('Create @label', array('@label' => $commerce_line_item_type->label()));
+  }
+
+}

--- a/modules/line_item/src/Controller/CommerceLineItemDevelController.php
+++ b/modules/line_item/src/Controller/CommerceLineItemDevelController.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce\Controller\CommerceLineItemDevelController.
+ */
+
+namespace Drupal\commerce_line_item\Controller;
+
+use Drupal\commerce_line_item\CommerceLineItemInterface;
+use Drupal\commerce_line_item\CommerceLineItemTypeInterface;
+use Drupal\devel\Controller\DevelController;
+
+/**
+ * Returns responses for Commerce Line item devel routes.
+ */
+class CommerceLineItemDevelController extends DevelController {
+
+  /**
+   * Dump devel information for a Commerce Line item Type.
+   *
+   * @param \Drupal\commerce_line_item\CommerceLineItemTypeInterface $line_item_type
+   *
+   * @return string
+   */
+  public function lineItemTypeLoad(CommerceLineItemTypeInterface $line_item_type) {
+    return $this->loadObject('line_item_type', $line_item_type);
+  }
+
+  /**
+   * Dump devel information for a Commerce Line item.
+   *
+   * @param \Drupal\commerce_line_item\CommerceLineItemInterface $line_item
+   *
+   * @return string
+   */
+  public function lineItemLoad(CommerceLineItemInterface $line_item) {
+    return $this->loadObject('line_item', $line_item);
+  }
+
+}

--- a/modules/line_item/src/Entity/CommerceLineItem.php
+++ b/modules/line_item/src/Entity/CommerceLineItem.php
@@ -1,0 +1,355 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_line_item\Entity\CommerceLineItem.
+ */
+
+namespace Drupal\commerce_line_item\Entity;
+
+use Drupal\commerce_line_item\CommerceLineItemInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Defines the Commerce Line item entity.
+ *
+ * @ContentEntityType(
+ *   id = "commerce_line_item",
+ *   label = @Translation("Line Item"),
+ *   handlers = {
+ *     "list_builder" = "Drupal\commerce_line_item\CommerceLineItemListBuilder",
+ *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "form" = {
+ *       "add" = "Drupal\commerce_line_item\Form\CommerceLineItemForm",
+ *       "edit" = "Drupal\commerce_line_item\Form\CommerceLineItemForm",
+ *       "delete" = "Drupal\commerce_line_item\Form\CommerceLineItemDeleteForm"
+ *     }
+ *   },
+ *   base_table = "commerce_line_item",
+ *   admin_permission = "administer orders",
+ *   fieldable = TRUE,
+ *   entity_keys = {
+ *     "id" = "line_item_id",
+ *     "uuid" = "uuid",
+ *     "revision" = "revision_id",
+ *     "bundle" = "type"
+ *   },
+ *   links = {
+ *     "edit-form" = "entity.commerce_line_item.edit_form",
+ *     "delete-form" = "entity.commerce_line_item.delete_form"
+ *   },
+ *   bundle_entity_type = "commerce_line_item_type",
+ *   field_ui_base_route = "entity.commerce_line_item_type.edit_form",
+ * )
+ */
+class CommerceLineItem extends ContentEntityBase implements CommerceLineItemInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function preCreate(EntityStorageInterface $storage_controller, array &$values) {
+    parent::preCreate($storage_controller, $values);
+    $values += array(
+      'uid' => \Drupal::currentUser()->id(),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preSave(EntityStorageInterface $storage) {
+    parent::preSave($storage);
+
+    // If no owner has been set explicitly, make the current user the owner.
+    if (!$this->getOwner()) {
+      $this->setOwnerId(\Drupal::currentUser()->id());
+    }
+
+    // If no revision author has been set explicitly, make the line item owner the
+    // revision author.
+    if (!$this->getRevisionAuthor()) {
+      $this->setRevisionAuthorId($this->getOwnerId());
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preSaveRevision(EntityStorageInterface $storage, \stdClass $record) {
+    parent::preSaveRevision($storage, $record);
+
+    if (!$this->isNewRevision() && isset($this->original) && (!isset($record->revision_log) || $record->revision_log === '')) {
+      // If we are updating an existing line item without adding a new revision, we
+      // need to make sure $entity->revision_log is reset whenever it is empty.
+      // Therefore, this code allows us to avoid clobbering an existing log
+      // entry with an empty one.
+      $record->revision_log = $this->original->revision_log->value;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getType() {
+    return $this->bundle();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStatus() {
+    return $this->get('status')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setStatus($status) {
+    $this->set('status', $status);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCreatedTime() {
+    return $this->get('created')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCreatedTime($timestamp) {
+    $this->set('created', $timestamp);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getChangedTime() {
+    return $this->get('changed')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOwner() {
+    return $this->get('uid')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOwnerId() {
+    return $this->get('uid')->target_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOwnerId($uid) {
+    $this->set('uid', $uid);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOwner(UserInterface $account) {
+    $this->set('uid', $account->id());
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRevisionCreationTime() {
+    return $this->get('revision_timestamp')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRevisionCreationTime($timestamp) {
+    $this->set('revision_timestamp', $timestamp);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRevisionAuthor() {
+    return $this->get('revision_uid')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRevisionAuthorId($uid) {
+    $this->set('revision_uid', $uid);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getData() {
+    return $this->get('data')->first()->getValue();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setData($data) {
+    $this->set('data', array($data));
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields['line_item_id'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Line Item ID'))
+      ->setDescription(t('The line item ID.'))
+      ->setReadOnly(TRUE)
+      ->setSetting('unsigned', TRUE);
+
+    $fields['uuid'] = BaseFieldDefinition::create('uuid')
+      ->setLabel(t('UUID'))
+      ->setDescription(t('The line item UUID.'))
+      ->setReadOnly(TRUE);
+
+    $fields['revision_id'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Revision ID'))
+      ->setDescription(t('The line item revision ID.'))
+      ->setReadOnly(TRUE)
+      ->setSetting('unsigned', TRUE);
+
+    $fields['type'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Type'))
+      ->setDescription(t('The line item type.'))
+      ->setSetting('target_type', 'commerce_line_item_type')
+      ->setReadOnly(TRUE);
+
+    $fields['uid'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Owner'))
+      ->setDescription(t('The user that owns this line item.'))
+      ->setRevisionable(TRUE)
+      ->setSetting('target_type', 'user')
+      ->setSetting('handler', 'default')
+      ->setDefaultValueCallback('Drupal\commerce_line_item\Entity\CommerceLineItem::getCurrentUserId')
+      ->setTranslatable(TRUE)
+      ->setDisplayOptions('view', array(
+        'label' => 'hidden',
+        'type' => 'author',
+        'weight' => 0,
+      ))
+      ->setDisplayOptions('form', array(
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 5,
+        'settings' => array(
+          'match_operator' => 'CONTAINS',
+          'size' => '60',
+          'autocomplete_type' => 'tags',
+          'placeholder' => '',
+        ),
+      ))
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['status'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Status'))
+      ->setDescription(t('The status name of this line item.'))
+      ->setRequired(TRUE)
+      ->setRevisionable(TRUE)
+      ->setDefaultValue('')
+      ->setSetting('max_length', 255)
+      ->setDisplayOptions('view', array(
+        'label' => 'hidden',
+        'type' => 'string',
+        'weight' => 0,
+      ))
+      ->setDisplayOptions('form', array(
+        'type' => 'hidden',
+        'weight' => -1,
+      ))
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Created'))
+      ->setDescription(t('The time that the line item was created.'))
+      ->setRequired(TRUE)
+      ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE)
+      ->setDisplayOptions('view', array(
+        'label' => 'hidden',
+        'type' => 'timestamp',
+        'weight' => 0,
+      ))
+      ->setDisplayOptions('form', array(
+        'type' => 'datetime_timestamp',
+        'weight' => 10,
+      ))
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(t('Changed'))
+      ->setDescription(t('The time that the line item was last edited.'))
+      ->setRequired(TRUE)
+      ->setRevisionable(TRUE);
+
+    $fields['line_items'] = BaseFieldDefinition::create('map')
+      ->setLabel(t('Line items'))
+      ->setDescription(t('A serialized array of line items.'));
+
+    $fields['data'] = BaseFieldDefinition::create('map')
+      ->setLabel(t('Data'))
+      ->setDescription(t('A serialized array of additional data.'));
+
+    $fields['revision_timestamp'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Revision timestamp'))
+      ->setDescription(t('The time that the current revision was created.'))
+      ->setQueryable(FALSE)
+      ->setRevisionable(TRUE);
+
+    $fields['revision_uid'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Revision user ID'))
+      ->setDescription(t('The user ID of the author of the current revision.'))
+      ->setSetting('target_type', 'user')
+      ->setQueryable(FALSE)
+      ->setRevisionable(TRUE);
+
+    $fields['revision_log'] = BaseFieldDefinition::create('string_long')
+      ->setLabel(t('Revision log message'))
+      ->setDescription(t('The log entry explaining the changes in this revision.'))
+      ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE)
+      ->setDisplayOptions('form', array(
+        'type' => 'string_textarea',
+        'weight' => 25,
+        'settings' => array(
+          'rows' => 4,
+        ),
+      ));
+
+    return $fields;
+  }
+
+  /**
+   * Default value callback for 'uid' base field definition.
+   *
+   * @see ::baseFieldDefinitions()
+   *
+   * @return array
+   *   An array of default values.
+   */
+  public static function getCurrentUserId() {
+    return array(\Drupal::currentUser()->id());
+  }
+
+}

--- a/modules/line_item/src/Entity/CommerceLineItemType.php
+++ b/modules/line_item/src/Entity/CommerceLineItemType.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_line_item\Entity\CommerceLineItemType.
+ */
+
+namespace Drupal\commerce_line_item\Entity;
+
+use Drupal\commerce_line_item\CommerceLineItemTypeInterface;
+use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
+
+/**
+ * Defines the Line item type configuration entity.
+ *
+ * @ConfigEntityType(
+ *   id = "commerce_line_item_type",
+ *   label = @Translation("Line item type"),
+ *   handlers = {
+ *     "form" = {
+ *       "add" = "Drupal\commerce_line_item\Form\CommerceLineItemTypeForm",
+ *       "edit" = "Drupal\commerce_line_item\Form\CommerceLineItemTypeForm",
+ *       "delete" = "Drupal\commerce_line_item\Form\CommerceLineItemTypeDeleteForm"
+ *     },
+ *     "list_builder" = "Drupal\commerce_line_item\CommerceLineItemTypeListBuilder",
+ *   },
+ *   admin_permission = "administer line item types",
+ *   config_prefix = "commerce_line_item_type",
+ *   bundle_of = "commerce_line_item",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "label",
+ *     "uuid" = "uuid"
+ *   },
+ *   links = {
+ *     "edit-form" = "entity.commerce_line_item_type.edit_form",
+ *     "delete-form" = "entity.commerce_line_item_type.delete_form"
+ *   }
+ * )
+ */
+class CommerceLineItemType extends ConfigEntityBundleBase implements CommerceLineItemTypeInterface {
+
+  /**
+   * The line item type ID.
+   *
+   * @var string
+   */
+  protected $id;
+
+  /**
+   * The line item type label.
+   *
+   * @var string
+   */
+  protected $label;
+
+  /**
+   * A brief description of this line item type.
+   *
+   * @var string
+   */
+  protected $description;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return $this->description;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setDescription($description) {
+    $this->description = $description;
+    return $this;
+  }
+
+}

--- a/modules/line_item/src/Form/CommerceLineItemDeleteForm.php
+++ b/modules/line_item/src/Form/CommerceLineItemDeleteForm.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_order\Form\CommerceOrderDeleteForm.
+ */
+
+namespace Drupal\commerce_order\Form;
+
+use Drupal\Core\Entity\ContentEntityConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Provides a form for deleting an order.
+ */
+class CommerceOrderDeleteForm extends ContentEntityConfirmFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return t('Are you sure you want to delete the order %order_label?', array('%order_label' => $this->entity->label()));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.commerce_order.list');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return t('Delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    try {
+      $this->entity->delete();
+      $order_type = $this->entity->type->entity->label();
+      $form_state->setRedirectUrl($this->getCancelUrl());
+      drupal_set_message($this->t('@type %order_label has been deleted.', array('@type' => $order_type, '%order_label' => $this->entity->label())));
+      $this->logger('commerce_order')->notice('@type: deleted %order_label.', array('@type' => $this->entity->bundle(), '%order_label' => $this->entity->label()));
+    }
+    catch (\Exception $e) {
+      drupal_set_message($this->t('The order %order_label could not be deleted.', array('%order_label' => $this->entity->label())), 'error');
+      $this->logger('commerce_order')->error($e);
+    }
+  }
+
+}

--- a/modules/line_item/src/Form/CommerceLineItemForm.php
+++ b/modules/line_item/src/Form/CommerceLineItemForm.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @file
+ * Definition of Drupal\commerce_line_item\Form\CommerceLineItemForm.
+ */
+namespace Drupal\commerce_line_item\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form controller for the commerce_line_item entity edit forms.
+ */
+class CommerceLineItemForm extends ContentEntityForm {
+
+  /**
+   * Overrides Drupal\Core\Entity\EntityFormController::save().
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    try {
+      $this->entity->save();
+      drupal_set_message($this->t('The order %order_label has been successfully saved.', array('%order_label' => $this->entity->label())));
+    }
+    catch (\Exception $e) {
+      drupal_set_message($this->t('The order %order_label could not be saved.', array('%order_label' => $this->entity->label())), 'error');
+      $this->logger('commerce_line_item')->error($e);
+    }
+    $form_state->setRedirect('entity.commerce_line_item.list');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    /* @var \Drupal\commerce_line_item\Entity\CommerceLineItem $order */
+    $order = $this->entity;
+    $current_user = $this->currentUser();
+
+    $form['advanced'] = array(
+      '#type' => 'vertical_tabs',
+      '#attributes' => array('class' => array('entity-meta')),
+      '#weight' => 99,
+    );
+    $form = parent::form($form, $form_state);
+
+    $form['order_status'] = array(
+      '#type' => 'details',
+      '#title' => t('Order status'),
+      '#group' => 'advanced',
+      '#attributes' => array(
+        'class' => array('order-form-order-status'),
+      ),
+      '#attached' => array(
+        'library' => array('commerce_line_item/drupal.commerce_line_item'),
+      ),
+      '#weight' => 90,
+      '#optional' => TRUE,
+    );
+
+    if (isset($form['status'])) {
+      $form['status']['#group'] = 'order_status';
+    }
+
+    $form['revision'] = array(
+      '#type' => 'checkbox',
+      '#title' => $this->t('Create new revision'),
+      '#default_value' => $order->isNewRevision(),
+      '#access' => $current_user->hasPermission('administer products'),
+      '#group' => 'order_status',
+      '#weight' => 10,
+    );
+
+    $form['revision_log'] += array(
+      '#states' => array(
+        'visible' => array(
+          ':input[name="revision"]' => array('checked' => TRUE),
+        ),
+      ),
+      '#group' => 'order_status',
+    );
+
+    // Order authoring information for administrators.
+    $form['author'] = array(
+      '#type' => 'details',
+      '#title' => t('Authoring information'),
+      '#group' => 'advanced',
+      '#attributes' => array(
+        'class' => array('order-form-author'),
+      ),
+      '#attached' => array(
+        'library' => array('commerce_line_item/drupal.commerce_line_item'),
+      ),
+      '#weight' => 91,
+      '#optional' => TRUE,
+    );
+
+    if (isset($form['uid'])) {
+      $form['uid']['#group'] = 'author';
+    }
+
+    if (isset($form['mail'])) {
+      $form['mail']['#group'] = 'author';
+    }
+
+    if (isset($form['created'])) {
+      $form['created']['#group'] = 'author';
+    }
+
+    return $form;
+  }
+
+}

--- a/modules/line_item/src/Form/CommerceLineItemTypeDeleteForm.php
+++ b/modules/line_item/src/Form/CommerceLineItemTypeDeleteForm.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_line_item\Form\CommerceLineItemTypeDeleteForm.
+ */
+
+namespace Drupal\commerce_line_item\Form;
+
+use Drupal\Core\Entity\EntityConfirmFormBase;
+use Drupal\Core\Entity\Query\QueryFactory;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Builds the form to delete an line item type.
+ */
+class CommerceLineItemTypeDeleteForm extends EntityConfirmFormBase {
+
+  /**
+   * The query factory to create entity queries.
+   *
+   * @var \Drupal\Core\Entity\Query\QueryFactory
+   */
+  protected $queryFactory;
+
+  /**
+   * Constructs a new CommerceLineItemTypeDeleteForm object.
+   *
+   * @param \Drupal\Core\Entity\Query\QueryFactory $query_factory
+   *   The entity query object.
+   */
+  public function __construct(QueryFactory $query_factory) {
+    $this->queryFactory = $query_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.query')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to delete the line item type %type?', array('%type' => $this->entity->label()));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.commerce_line_item_type.list');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $num_orders = $this->queryFactory->get('commerce_line_item')
+      ->condition('type', $this->entity->id())
+      ->count()
+      ->execute();
+    if ($num_orders) {
+      $caption = '<p>' . $this->formatPlural($num_orders, '%type is used by 1 line item on your site. You can not remove this line item type until you have removed all of the %type line items.', '%type is used by @count line items on your site. You may not remove %type until you have removed all of the %type line items.', array('%type' => $this->entity->label())) . '</p>';
+      $form['#title'] = $this->getQuestion();
+      $form['description'] = array('#markup' => $caption);
+      return $form;
+    }
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    try {
+      $this->entity->delete();
+      $form_state->setRedirectUrl($this->getCancelUrl());
+      drupal_set_message($this->t('Line item type %label has been deleted.', array('%label' => $this->entity->label())));
+    }
+    catch (\Exception $e) {
+      drupal_set_message($this->t('Line item type %label could not be deleted.', array('%label' => $this->entity->label())), 'error');
+      $this->logger('commerce_line_item')->error($e);
+    }
+  }
+
+}

--- a/modules/line_item/src/Form/CommerceLineItemTypeForm.php
+++ b/modules/line_item/src/Form/CommerceLineItemTypeForm.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\commerce_line_item\Form\CommerceLineItemTypeForm.
+ */
+
+namespace Drupal\commerce_line_item\Form;
+
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class CommerceLineItemTypeForm extends EntityForm {
+
+  /**
+   * The line_item type storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $lineItemTypeStorage;
+
+  /**
+   * Create an CommerceLineItemTypeForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityStorageInterface $line_item_type_storage
+   *   The line_item type storage.
+   */
+  public function __construct(EntityStorageInterface $line_item_type_storage) {
+    // Setup object members.
+    $this->lineItemTypeStorage = $line_item_type_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    /** @var \Drupal\Core\Entity\EntityManagerInterface $entity_manager */
+   $entity_manager = $container->get('entity.manager');
+   return new static($entity_manager->getStorage('commerce_line_item_type'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+    $line_item_type = $this->entity;
+
+    $form['label'] = array(
+      '#type' => 'textfield',
+      '#title' => $this->t('Label'),
+      '#maxlength' => 255,
+      '#default_value' => $line_item_type->label(),
+      '#description' => $this->t('Label for the line item type.'),
+      '#required' => TRUE,
+    );
+
+    $form['id'] = array(
+      '#type' => 'machine_name',
+      '#default_value' => $line_item_type->id(),
+      '#machine_name' => array(
+        'exists' => array($this->line_itemTypeStorage, 'load'),
+        'source' => array('label'),
+      ),
+      '#disabled' => !$line_item_type->isNew(),
+    );
+
+    $form['description'] = array(
+      '#title' => t('Description'),
+      '#type' => 'textarea',
+      '#default_value' => $line_item_type->getDescription(),
+      '#description' => $this->t('Description of this line item type'),
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $line_item_type = $this->entity;
+
+    try {
+      $line_item_type->save();
+      drupal_set_message($this->t('Saved the %label line item type.', array(
+        '%label' => $line_item_type->label(),
+      )));
+      $form_state->setRedirect('entity.commerce_line_item_type.list');
+    }
+    catch (\Exception $e) {
+      $this->logger('commerce_line_item')->error($e);
+      drupal_set_message($this->t('The %label line item type was not saved.', array(
+        '%label' => $line_item_type->label(),
+      )), 'error');
+      $form_state->setRebuild();
+    }
+  }
+
+}

--- a/modules/order/commerce_order.info.yml
+++ b/modules/order/commerce_order.info.yml
@@ -5,3 +5,5 @@ package: Commerce
 core: 8.x
 dependencies:
   - commerce
+  - commerce_line_item
+  - entity_reference

--- a/modules/order/src/Entity/CommerceOrder.php
+++ b/modules/order/src/Entity/CommerceOrder.php
@@ -422,9 +422,11 @@ class CommerceOrder extends ContentEntityBase implements CommerceOrderInterface 
       ->setRequired(TRUE)
       ->setRevisionable(TRUE);
 
-    $fields['line_items'] = BaseFieldDefinition::create('map')
+    $fields['line_items'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Line items'))
-      ->setDescription(t('A serialized array of line items.'));
+      ->setDescription(t('An entity reference to line items.'))
+      ->setCardinality(-1)
+      ->setSetting('target_type', 'commerce_line_item');
 
     $fields['hostname'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Hostname'))

--- a/modules/order/src/Form/CommerceOrderTypeForm.php
+++ b/modules/order/src/Form/CommerceOrderTypeForm.php
@@ -22,7 +22,7 @@ class CommerceOrderTypeForm extends EntityForm {
   protected $orderTypeStorage;
 
   /**
-   * Create an IndexForm object.
+   * Create an CommerceOrderTypeForm object.
    *
    * @param \Drupal\Core\Entity\EntityStorageInterface $order_type_storage
    *   The order type storage.

--- a/modules/product/commerce_product.info.yml
+++ b/modules/product/commerce_product.info.yml
@@ -5,5 +5,6 @@ package: Commerce
 core: 8.x
 dependencies:
   - commerce
+  - commerce_line_item
   - commerce_price
   - text

--- a/modules/product/config/install/commerce_line_item.commerce_line_item_type.product.yml
+++ b/modules/product/config/install/commerce_line_item.commerce_line_item_type.product.yml
@@ -1,0 +1,3 @@
+id: 'product'
+label: 'Product Line Item'
+description: 'A product line item type.'

--- a/modules/product/config/install/field.field.commerce_line_item.product.product.yml
+++ b/modules/product/config/install/field.field.commerce_line_item.product.product.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_line_item.commerce_line_item_type.product
+    - field.storage.commerce_line_item.product
+  module:
+    - entity_reference
+id: commerce_line_item.product.field_product
+field_name: product
+entity_type: commerce_line_item
+bundle: product
+label: Product
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings:
+    sort:
+      field: _none
+third_party_settings: {  }
+field_type: entity_reference

--- a/modules/product/config/install/field.storage.commerce_line_item.product.yml
+++ b/modules/product/config/install/field.storage.commerce_line_item.product.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_line_item
+    - entity_reference
+id: commerce_line_item.field_product
+field_name: product
+entity_type: commerce_line_item
+type: entity_reference
+settings:
+  target_type: commerce_product
+module: entity_reference
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false


### PR DESCRIPTION
My initial development of a line item type

There are three issues that is see and are all related to Drupal core.
1.  Entity reference configuration requires the selection of the target entity and bundles, there is no option for all bundles. The line items field on orders needs to be able to reference all line item types; products, shipping, etc.
2.  The same applies to the the product line item type which needs to be able to refference all product types.
3.  The config is only able to create the line items field on the order bundle, if a user creates a new type of order type from the UI it will not have the line items field on it which will be required. (This also applies to the price field on products)
