### PR TITLE
Added missing langcode entity key definitions

### DIFF
--- a/modules/product/src/Entity/CommerceProduct.php
+++ b/modules/product/src/Entity/CommerceProduct.php
@@ -44,6 +44,7 @@ use Drupal\user\UserInterface;
  *   entity_keys = {
  *     "id" = "product_id",
  *     "label" = "title",
+ *     "langcode" = "langcode",
  *     "uuid" = "uuid",
  *     "revision" = "revision_id",
  *     "bundle" = "type"

--- a/src/Entity/CommerceStore.php
+++ b/src/Entity/CommerceStore.php
@@ -41,6 +41,7 @@ use Drupal\user\UserInterface;
  *     "id" = "store_id",
  *     "bundle" = "type",
  *     "label" = "name",
+ *     "langcode" = "langcode",
  *     "uuid" = "uuid"
  *   },
  *   links = {


### PR DESCRIPTION
The installation of Commerce is currently not any more possible due to a change in core to the entity definition. 
Entity type need to add a langcode key in the entity type definition

For more details, have a look to the core issue [#2143729](https://www.drupal.org/node/2143729)
