### PR TITLE
Update commerce for the Change Record "Entity annotation link templates ...

### DIFF
--- a/commerce.routing.yml
+++ b/commerce.routing.yml
@@ -100,7 +100,7 @@ entity.commerce_store_type.list:
     _permission: 'administer store types'
 
 entity.commerce_store_type.edit_form:
-  path: '/admin/commerce/config/store/types/{commerce_store_type}'
+  path: '/admin/commerce/config/store/types/{commerce_store_type}/edit'
   defaults:
     _entity_form: 'commerce_store_type.edit'
     _title: 'Edit a store type'

--- a/modules/line_item/src/Entity/CommerceLineItem.php
+++ b/modules/line_item/src/Entity/CommerceLineItem.php
@@ -39,11 +39,11 @@ use Drupal\user\UserInterface;
  *     "bundle" = "type"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_line_item.edit_form",
- *     "delete-form" = "entity.commerce_line_item.delete_form"
+ *     "edit-form" = "/admin/commerce/config/line-item/{commerce_line_item}/edit",
+ *     "delete-form" = "/admin/commerce/config/line-item/{commerce_line_item}/delete"
  *   },
  *   bundle_entity_type = "commerce_line_item_type",
- *   field_ui_base_route = "entity.commerce_line_item_type.edit_form",
+ *   field_ui_base_route = "/admin/commerce/config/line-item/{commerce_line_item}/edit",
  * )
  */
 class CommerceLineItem extends ContentEntityBase implements CommerceLineItemInterface {

--- a/modules/line_item/src/Entity/CommerceLineItemType.php
+++ b/modules/line_item/src/Entity/CommerceLineItemType.php
@@ -33,8 +33,8 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_line_item_type.edit_form",
- *     "delete-form" = "entity.commerce_line_item_type.delete_form"
+ *     "edit-form" = "/admin/commerce/config/line-item-types/{commerce_line_item_type}/edit",
+ *     "delete-form" = "/admin/commerce/config/line-item-types/{commerce_line_item_type}/edit"
  *   }
  * )
  */

--- a/modules/order/commerce_order.routing.yml
+++ b/modules/order/commerce_order.routing.yml
@@ -69,6 +69,16 @@ entity.commerce_order_type.list:
   requirements:
     _permission: 'administer order types'
 
+entity.commerce_order_type.admin_form:
+  path: '/admin/commerce/config/order-types/{commerce_order_type}'
+  defaults:
+    _entity_form: 'commerce_order_type.edit'
+    _title: 'Edit an order type'
+  options:
+    _admin_route: TRUE
+  requirements:
+    _entity_access: 'commerce_order_type.update'
+
 entity.commerce_order.edit_form:
   path: '/admin/commerce/orders/{commerce_order}/edit'
   defaults:
@@ -88,6 +98,16 @@ entity.commerce_order.list:
     _admin_route: TRUE
   requirements:
     _permission: 'administer orders'
+
+entity.commerce_order_type.edit_form:
+  path: '/admin/commerce/config/order-types/{commerce_order_type}/edit'
+  defaults:
+    _entity_form: commerce_order_type.edit
+    _title: 'Edit order type'
+  options:
+    _admin_route: TRUE
+  requirements:
+    _entity_access: 'commerce_order_type.update'
 
 entity.commerce_order_type.add_form:
   path: '/admin/commerce/config/order-types/add'

--- a/modules/order/src/Entity/CommerceOrder.php
+++ b/modules/order/src/Entity/CommerceOrder.php
@@ -40,8 +40,8 @@ use Drupal\user\UserInterface;
  *     "bundle" = "type"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_order.edit_form",
- *     "delete-form" = "entity.commerce_order.delete_form"
+ *     "edit-form" = "/admin/commerce/orders/{commerce_order}/edit",
+ *     "delete-form" = "/admin/commerce/orders/{commerce_order}/delete"
  *   },
  *   bundle_entity_type = "commerce_order_type",
  *   field_ui_base_route = "entity.commerce_order.admin_form",

--- a/modules/order/src/Entity/CommerceOrderType.php
+++ b/modules/order/src/Entity/CommerceOrderType.php
@@ -33,8 +33,8 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_order.admin_form",
- *     "delete-form" = "entity.commerce_order_type.delete_form"
+ *     "edit-form" = "/admin/commerce/config/order-types/{commerce_order_type}/edit",
+ *     "delete-form" = "/admin/commerce/config/order-types/{commerce_order_type}/delete"
  *   }
  * )
  */

--- a/modules/payment/src/Entity/CommercePaymentInfo.php
+++ b/modules/payment/src/Entity/CommercePaymentInfo.php
@@ -41,8 +41,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *   permission_granularity = "bundle",
  *   admin_permission = "administer payment information",
  *   links = {
- *     "edit-form" = "entity.commerce_payment_info.edit_form",
- *     "delete-form" = "entity.commerce_payment_info.delete_form"
+ *     "edit-form" = "/admin/commerce/payment-info/{commerce_payment_info}/edit",
+ *     "delete-form" = "/admin/commerce/config/payment-info-types/{commerce_payment_info_type}/delete"
  *   },
  * )
  */

--- a/modules/payment/src/Entity/CommercePaymentInfoType.php
+++ b/modules/payment/src/Entity/CommercePaymentInfoType.php
@@ -33,8 +33,8 @@ use Drupal\commerce_payment\CommercePaymentInfoTypeInterface;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_payment_info.admin_form",
- *     "delete-form" = "entity.commerce_payment_info_type.delete_form"
+ *     "edit-form" = "/admin/commerce/config/payment-info-types/{commerce_payment_info_type}",
+ *     "delete-form" = "/admin/commerce/payment-info/{commerce_payment_info}/delete"
  *   }
  * )
  */

--- a/modules/price/src/Entity/CommerceCurrency.php
+++ b/modules/price/src/Entity/CommerceCurrency.php
@@ -33,8 +33,8 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "status" = "status"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_currency.edit_form",
- *     "delete-form" = "entity.commerce_currency.delete_form"
+ *     "edit-form" = "/admin/commerce/config/currency/{commerce_currency}",
+ *     "delete-form" = "/admin/commerce/config/currency/{commerce_currency}/delete"
  *   }
  * )
  */

--- a/modules/price/src/Entity/CommerceNumberFormat.php
+++ b/modules/price/src/Entity/CommerceNumberFormat.php
@@ -33,8 +33,8 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "status" = "status"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_number_format.edit_form",
- *     "delete-form" = "entity.commerce_number_format.delete_form"
+ *     "edit-form" = "/admin/commerce/config/number-format/{commerce_number_format}",
+ *     "delete-form" = "/admin/commerce/config/number-format/{commerce_number_format}/delete"
  *   }
  * )
  */

--- a/modules/product/src/Entity/CommerceProduct.php
+++ b/modules/product/src/Entity/CommerceProduct.php
@@ -50,8 +50,8 @@ use Drupal\user\UserInterface;
  *     "bundle" = "type"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_product.edit_form",
- *     "delete-form" = "entity.commerce_product.delete_form",
+ *     "edit-form" = "/product/{commerce_product}/edit",
+ *     "delete-form" = "/product/{commerce_product}/delete",
  *   },
  *   bundle_entity_type = "commerce_product_type",
  *   field_ui_base_route = "entity.commerce_product_type.edit_form",

--- a/modules/product/src/Entity/CommerceProductType.php
+++ b/modules/product/src/Entity/CommerceProductType.php
@@ -34,8 +34,8 @@ use Drupal\commerce_product\CommerceProductTypeInterface;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_product_type.edit_form",
- *     "delete-form" = "entity.commerce_product_type.delete_form"
+ *     "edit-form" = "/admin/commerce/config/product-types/{commerce_product_type}/edit",
+ *     "delete-form" = "/admin/commerce/config/product-types/{commerce_product_type}/delete"
  *   }
  * )
  */

--- a/modules/tax/src/Entity/CommerceTaxRate.php
+++ b/modules/tax/src/Entity/CommerceTaxRate.php
@@ -37,8 +37,8 @@ use CommerceGuys\Tax\Model\TaxRateAmountInterface;
  *     "type" = "type"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_tax_rate.edit_form",
- *     "delete-form" = "entity.commerce_tax_rate.delete_form"
+ *     "edit-form" = "/admin/commerce/config/tax/rate/{commerce_tax_rate}/edit",
+ *     "delete-form" = "/admin/commerce/config/tax/rate/{commerce_tax_rate}/delete"
  *   }
  * )
  */

--- a/modules/tax/src/Entity/CommerceTaxRateAmount.php
+++ b/modules/tax/src/Entity/CommerceTaxRateAmount.php
@@ -35,8 +35,8 @@ use CommerceGuys\Tax\Model\TaxRateAmountInterface;
  *     "rate" = "rate"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_tax_rate_amount.edit_form",
- *     "delete-form" = "entity.commerce_tax_rate_amount.delete_form"
+ *     "edit-form" = "/admin/commerce/config/tax/amount/{commerce_tax_rate_amount}/edit",
+ *     "delete-form" = "/admin/commerce/config/tax/amount/{commerce_tax_rate_amount}/delete"
  *   }
  * )
  */

--- a/modules/tax/src/Entity/CommerceTaxType.php
+++ b/modules/tax/src/Entity/CommerceTaxType.php
@@ -37,8 +37,8 @@ use CommerceGuys\Tax\Model\TaxRateInterface;
  *     "rates" = "rates"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_tax_type.edit_form",
- *     "delete-form" = "entity.commerce_tax_type.delete_form"
+ *     "edit-form" = "/admin/commerce/config/tax/type/{commerce_tax_type}/edit",
+ *     "delete-form" = "/admin/commerce/config/tax/type/{commerce_tax_type}/delete"
  *   }
  * )
  */

--- a/src/Entity/CommerceStore.php
+++ b/src/Entity/CommerceStore.php
@@ -45,8 +45,8 @@ use Drupal\user\UserInterface;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_store.edit_form",
- *     "delete-form" = "entity.commerce_store.delete_form",
+ *     "edit-form" = "/admin/commerce/config/store/{commerce_store}/edit",
+ *     "delete-form" = "/admin/commerce/config/store/{commerce_store}/delete",
  *   },
  *   bundle_entity_type = "commerce_store_type",
  *   field_ui_base_route = "entity.commerce_store_type.edit_form",

--- a/src/Entity/CommerceStoreType.php
+++ b/src/Entity/CommerceStoreType.php
@@ -35,8 +35,8 @@ use Drupal\Core\Entity\EntityStorageException;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "edit-form" = "entity.commerce_store_type.edit_form",
- *     "delete-form" = "entity.commerce_store_type.delete_form"
+ *     "edit-form" = "/admin/commerce/config/store/types/{commerce_store_type}/edit",
+ *     "delete-form" = "/admin/commerce/config/store/types/{commerce_store_type}/delete"
  *   }
  * )
  */


### PR DESCRIPTION
...are paths again"

Also fixes various broken routes, as found throughout.

One thing to note is that CommercePaymentTransaction doesn't have a form either.
