### PR TITLE
Update to latest HEAD changes

### DIFF
--- a/modules/product/commerce_product.module
+++ b/modules/product/commerce_product.module
@@ -71,7 +71,7 @@ function commerce_product_form_field_ui_field_edit_form_alter(array &$form, Form
   // If the current field instance is attached to a product type,
   // and of a field type that defines an options list.
   $allowed_fields = array('options', 'taxonomy', 'entity_reference');
-  if ($field->entity_type == 'commerce_product' && in_array($form['#field']->module, $allowed_fields)) {
+  if ($field->entity_type == 'commerce_product' && in_array($field->get('fieldStorage')->get('module'), $allowed_fields)) {
     // Get the current instance's attribute settings for use as default values.
     $default_attribute_field = $field->getThirdPartySetting('commerce_product', 'attribute_field', FALSE);
     $default_attribute_widget = $field->getThirdPartySetting('commerce_product', 'attribute_widget', 'select');
@@ -131,7 +131,7 @@ function commerce_product_form_field_ui_field_edit_form_submit($form, FormStateI
   $field = $form_state->get('field');
   $values = $form_state->getValues();
   $allowed_fields = array('options', 'taxonomy', 'entity_reference');
-  if ($field->entity_type == 'commerce_product' && in_array($form['#field']->module, $allowed_fields)) {
+  if ($field->entity_type == 'commerce_product' && in_array($field->get('fieldStorage')->get('module'), $allowed_fields)) {
     // If the attribute field is checked, update the attribute fields.
     if ($values['field']['commerce_product']['attribute_field']) {
       $field->setThirdPartySetting('commerce_product', 'attribute_widget_title', $values['field']['commerce_product']['attribute_widget_title']);

--- a/modules/product/config/schema/commerce_product.schema.yml
+++ b/modules/product/config/schema/commerce_product.schema.yml
@@ -18,7 +18,7 @@ commerce_product.commerce_product_type.*:
       type: text
       label: 'Description'
 
-field_config.third_party.commerce_product:
+field.field.*.*.*.third_party.commerce_product:
   type: mapping
   label: 'Product attributes'
   mapping:


### PR DESCRIPTION
This fixes the commerce_product to not use $form['#field']->module.

This also fixes schema to get third party settings to work, as per https://www.drupal.org/node/2361775
