### PR TITLE
Issue #2416141: Remove digital boolean from product type

### DIFF
--- a/modules/product/config/schema/commerce_product.schema.yml
+++ b/modules/product/config/schema/commerce_product.schema.yml
@@ -11,9 +11,6 @@ commerce_product.commerce_product_type.*:
     revision:
       type: boolean
       label: 'Create new revision'
-    digital:
-      type: boolean
-      label: 'Products of this type represent digital services.'
     description:
       type: text
       label: 'Description'

--- a/modules/product/src/Entity/ProductType.php
+++ b/modules/product/src/Entity/ProductType.php
@@ -71,13 +71,6 @@ class ProductType extends ConfigEntityBundleBase implements ProductTypeInterface
   protected $description;
 
   /**
-   * Option to specify if the product type is a digital service.
-   *
-   * @var bool
-   */
-  protected $digital;
-
-  /**
    * The default revision setting for products of this type.
    *
    * @var bool
@@ -114,21 +107,6 @@ class ProductType extends ConfigEntityBundleBase implements ProductTypeInterface
    */
   public function setDescription($description) {
     $this->description = $description;
-    return $this;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function isDigital() {
-    return $this->digital ? TRUE : FALSE;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setDigital($digital) {
-    $this->digital = $digital;
     return $this;
   }
 

--- a/modules/product/src/Form/ProductTypeForm.php
+++ b/modules/product/src/Form/ProductTypeForm.php
@@ -40,12 +40,6 @@ class ProductTypeForm extends EntityForm {
       '#title' => $this->t('Description'),
       '#default_value' => $productType->getDescription(),
     );
-    $form['digital'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Digital'),
-      '#default_value' => $productType->isDigital(),
-      '#description' => t('Products of this type represent digital services.')
-    );
     $form['revision'] = array(
       '#type' => 'checkbox',
       '#title' => t('Create new revision'),

--- a/modules/product/src/ProductTypeInterface.php
+++ b/modules/product/src/ProductTypeInterface.php
@@ -32,22 +32,4 @@ interface ProductTypeInterface extends ConfigEntityInterface {
    */
   public function setDescription($description);
 
-  /**
-   * Returns the digital property of the product type.
-   *
-   * @return bool
-   *   The digital property value.
-   */
-  public function isDigital();
-
-  /**
-   * Sets the digital property of the product type.
-   *
-   * @param bool
-   *   The new value for the digital property.
-   *
-   * @return $this
-   */
-  public function setDigital($digital);
-
 }


### PR DESCRIPTION
There is no purpose for the field, it is to simplistic for tax, and anything for this requirement should be added by the Tax module.
There is also no other provision for digital services in Commerce core, so these should be provided by the module implementing the digital service.
