### PR TITLE
TaxResolver service

### DIFF
--- a/modules/tax/commerce_tax.services.yml
+++ b/modules/tax/commerce_tax.services.yml
@@ -2,3 +2,11 @@ services:
   commerce_tax.tax_type_importer_factory:
     class: Drupal\commerce_tax\TaxTypeImporterFactory
     arguments: ['@entity.manager', '@string_translation']
+  commerce_tax.tax_resolver:
+    class: Drupal\commerce_tax\TaxResolver
+  plugin.manager.commerce_tax.tax_type_resolver:
+    class: Drupal\commerce_tax\TaxTypeResolverManager
+    parent: default_plugin_manager
+  plugin.manager.commerce_tax.tax_rate_resolver:
+    class: Drupal\commerce_tax\TaxRateResolverManager
+    parent: default_plugin_manager

--- a/modules/tax/src/Annotation/TaxRateResolver.php
+++ b/modules/tax/src/Annotation/TaxRateResolver.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\commerce_tax\Annotation\TaxRateResolver.
+ */
+
+namespace Drupal\commerce_tax\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a TaxRate annotation object.
+ *
+ * Plugin Namespace: Plugin\commerce_tax\TaxRateResolver
+ *
+ * @see \Drupal\commerce_tax\TaxRateResolverManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class TaxRateResolver extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+}

--- a/modules/tax/src/Annotation/TaxTypeResolver.php
+++ b/modules/tax/src/Annotation/TaxTypeResolver.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\commerce_tax\Annotation\TaxTypeResolver.
+ */
+
+namespace Drupal\commerce_tax\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a TaxTypeResolver annotation object.
+ *
+ * Plugin Namespace: Plugin\CommerceTax\TaxTypeResolver
+ *
+ * @see \Drupal\commerce_tax\TaxTypeResolverManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class TaxTypeResolver extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+}

--- a/modules/tax/src/Plugin/CommerceTax/TaxRateResolver/DefaultTaxRateResolver.php
+++ b/modules/tax/src/Plugin/CommerceTax/TaxRateResolver/DefaultTaxRateResolver.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\commerce_tax\Plugin\CommerceTax\TaxRateResolver\DefaultTaxRateResolver.
+ */
+
+namespace Drupal\commerce_tax\Plugin\CommerceTax\TaxRateResolver;
+
+use CommerceGuys\Tax\Resolver\TaxRate\DefaultTaxRateResolver as BaseDefaultTaxRateResolver;
+
+/**
+ * Default Tax Rate Resolver.
+ *
+ * @TaxRateResolver(
+ *   id = "Default",
+ * )
+ */
+class DefaultTaxRateResolver extends BaseDefaultTaxRateResolver {
+
+}

--- a/modules/tax/src/Plugin/CommerceTax/TaxTypeResolver/CanadaTaxTypeResolver.php
+++ b/modules/tax/src/Plugin/CommerceTax/TaxTypeResolver/CanadaTaxTypeResolver.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\commerce_tax\Plugin\CommerceTax\TaxTypeResolver\EuTaxTypeResolver.
+ */
+
+namespace Drupal\commerce_tax\Plugin\CommerceTax\TaxTypeResolver;
+
+use CommerceGuys\Tax\Resolver\TaxType\CanadaTaxTypeResolver as BaseCanadaTaxTypeResolver;
+
+/**
+ * EU Tax Type Resolver.
+ *
+ * @TaxTypeResolver(
+ *   id = "CA",
+ * )
+ */
+class CanadaTaxTypeResolver extends BaseCanadaTaxTypeResolver {
+
+}

--- a/modules/tax/src/Plugin/CommerceTax/TaxTypeResolver/DefaultTaxTypeResolver.php
+++ b/modules/tax/src/Plugin/CommerceTax/TaxTypeResolver/DefaultTaxTypeResolver.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\commerce_tax\Plugin\CommerceTax\TaxTypeResolver\DefaultTaxTypeResolver.
+ */
+
+namespace Drupal\commerce_tax\Plugin\CommerceTax\TaxTypeResolver;
+
+use CommerceGuys\Tax\Resolver\TaxType\DefaultTaxTypeResolver as BaseDefaultTaxTypeResolver;
+
+/**
+ * Default Tax Type Resolver.
+ *
+ * @TaxTypeResolver(
+ *   id = "Default",
+ * )
+ */
+class DefaultTaxTypeResolver extends BaseDefaultTaxTypeResolver {
+
+}

--- a/modules/tax/src/Plugin/CommerceTax/TaxTypeResolver/EuTaxTypeResolver.php
+++ b/modules/tax/src/Plugin/CommerceTax/TaxTypeResolver/EuTaxTypeResolver.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\commerce_tax\Plugin\CommerceTax\TaxTypeResolver\EuTaxTypeResolver.
+ */
+
+namespace Drupal\commerce_tax\Plugin\CommerceTax\TaxTypeResolver;
+
+use CommerceGuys\Tax\Resolver\TaxType\EuTaxTypeResolver as BaseEuTaxTypeResolver;
+
+/**
+ * EU Tax Type Resolver.
+ *
+ * @TaxTypeResolver(
+ *   id = "EU",
+ * )
+ */
+class EuTaxTypeResolver extends BaseEuTaxTypeResolver {
+
+}

--- a/modules/tax/src/TaxRateResolverManager.php
+++ b/modules/tax/src/TaxRateResolverManager.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @file
+ * Contains TaxRateResolverManager.
+ */
+
+namespace Drupal\commerce_tax;
+
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * TaxRateResolver plugin manager.
+ */
+class TaxRateResolverManager extends DefaultPluginManager {
+
+  /**
+   * Constructs an TaxRateResolverManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations,
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/CommerceTax/TaxRateResolver', $namespaces, $module_handler, 'CommerceGuys\Tax\Resolver\TaxRate\TaxRateResolverInterface', 'Drupal\commerce_tax\Annotation\TaxRateResolver');
+
+    $this->alterInfo('tax_rate_resolver_info');
+    $this->setCacheBackend($cache_backend, 'tax_rate_resolvers');
+  }
+
+}

--- a/modules/tax/src/TaxResolver.php
+++ b/modules/tax/src/TaxResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce_tax\TaxResolverFactory.
+ */
+
+namespace Drupal\commerce_tax;
+
+use CommerceGuys\Tax\Resolver\TaxResolver as BaseTaxResolver;
+use CommerceGuys\Tax\Resolver\Engine\TaxTypeResolverEngine;
+use CommerceGuys\Tax\Resolver\Engine\TaxRateResolverEngine;
+use Drupal\commerce_tax\TaxTypeRepository;
+use Drupal\commerce_tax\Plugin\CommerceTax\TaxTypeResolver;
+
+class TaxResolver extends BaseTaxResolver {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct() {
+    // Tax Type Resolver.
+    $taxTypeRepository = new TaxTypeRepository();
+    $this->taxTypeResolverEngine = new TaxTypeResolverEngine();
+
+    $tax_type_resolver_manager = \Drupal::service('plugin.manager.commerce_tax.tax_type_resolver');
+    foreach ($tax_type_resolver_manager->getDefinitions() as $resolver) {
+      $this->taxTypeResolverEngine->add(new $resolver['class']($taxTypeRepository));
+    }
+
+    // Tax Rate Resolver.
+    $this->taxRateResolverEngine = new TaxRateResolverEngine();
+
+    $tax_rate_resolver_manager = \Drupal::service('plugin.manager.commerce_tax.tax_type_resolver');
+    foreach ($tax_rate_resolver_manager->getDefinitions() as $resolver) {
+      $this->taxRateResolverEngine->add(new $resolver['class']());
+    }
+
+  }
+
+}

--- a/modules/tax/src/TaxTypeRepository.php
+++ b/modules/tax/src/TaxTypeRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\commerce_tax;
+
+use CommerceGuys\Tax\Repository\TaxTypeRepositoryInterface;
+
+/**
+ * Manages tax types based on JSON definitions.
+ */
+class TaxTypeRepository implements TaxTypeRepositoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        return entity_load('commerce_tax_type', $id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAll()
+    {
+        return entity_load_multiple('commerce_tax_type');
+    }
+
+}

--- a/modules/tax/src/TaxTypeResolverManager.php
+++ b/modules/tax/src/TaxTypeResolverManager.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @file
+ * Contains TaxTypeResolverManager.
+ */
+
+namespace Drupal\commerce_tax;
+
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * TaxTypeResolver plugin manager.
+ */
+class TaxTypeResolverManager extends DefaultPluginManager {
+
+  /**
+   * Constructs an TaxTypeResolverManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations,
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/CommerceTax/TaxTypeResolver', $namespaces, $module_handler, 'CommerceGuys\Tax\Resolver\TaxType\TaxTypeResolverInterface', 'Drupal\commerce_tax\Annotation\TaxTypeResolver');
+
+    $this->alterInfo('tax_type_resolver_info');
+    $this->setCacheBackend($cache_backend, 'tax_type_resolvers');
+  }
+
+}


### PR DESCRIPTION
Example use:

``` PHP
$resolver = \Drupal::service('commerce_tax.tax_resolver')
$resolver->resolveAmounts(TaxableInterface $taxable, Context $context);
```
