### PR TITLE
Issue #2465115 by bojanz, vasike: Some corrections for module references...

### DIFF
--- a/modules/store/src/StoreInterface.php
+++ b/modules/store/src/StoreInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\commerce\StoreInterface.
+ * Contains \Drupal\commerce_store\StoreInterface.
  */
 
 namespace Drupal\commerce_store;
@@ -29,7 +29,7 @@ interface StoreInterface extends EntityInterface, EntityOwnerInterface {
    * @param string $name
    *   The new name of the store.
    *
-   * @return \Drupal\commerce\StoreInterface
+   * @return \Drupal\commerce_store\StoreInterface
    *   The class instance that this method is called on.
    */
   public function setName($name);
@@ -48,7 +48,7 @@ interface StoreInterface extends EntityInterface, EntityOwnerInterface {
    * @param string $mail
    *   The new e-mail address of the store.
    *
-   * @return \Drupal\commerce\StoreInterface
+   * @return \Drupal\commerce_store\StoreInterface
    *   The class instance that this method is called on.
    */
   public function setEmail($mail);
@@ -67,7 +67,7 @@ interface StoreInterface extends EntityInterface, EntityOwnerInterface {
    * @param string $currency_code
    *   The new default currency code of the store.
    *
-   * @return \Drupal\commerce\StoreInterface
+   * @return \Drupal\commerce_store\StoreInterface
    *   The class instance that this method is called on.
    */
   public function setDefaultCurrency($currency_code);

--- a/modules/store/src/StoreListBuilder.php
+++ b/modules/store/src/StoreListBuilder.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains Drupal\commerce\StoreListBuilder.
+ * Contains Drupal\commerce_store\StoreListBuilder.
  */
 
 namespace Drupal\commerce_store;

--- a/modules/store/src/StoreTypeInterface.php
+++ b/modules/store/src/StoreTypeInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains Drupal\commerce\StoreTypeInterface.
+ * Contains Drupal\commerce_store\StoreTypeInterface.
  */
 
 namespace Drupal\commerce_store;

--- a/modules/store/src/StoreTypeListBuilder.php
+++ b/modules/store/src/StoreTypeListBuilder.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\commerce\StoreTypeListBuilder.
+ * Contains \Drupal\commerce_store\StoreTypeListBuilder.
  */
 
 namespace Drupal\commerce_store;


### PR DESCRIPTION
... in comments, commerce_store instead of (initial) commerce.

https://www.drupal.org/node/2465115
