### PR TITLE
Add inline_entity_form to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,8 @@ before_script:
   - composer drupal-rebuild
   - composer update --prefer-source -n --verbose
   - cd ..
+  # Remove this one inline_entity_form is on drupal.org
+  - git clone https://github.com/webflo/inline_entity_form.git modules/inline_entity_form
   - drush en -y commerce commerce_product commerce_order
 
 script:


### PR DESCRIPTION
As this is not on Drupal.org, the module can not be downloaded. Once this is on drupal.org, remove this line.
