### PR TITLE
Added information to download inline_entity_form as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Installation
 
 Preparation:
 
-1.  Install the -dev versions of Drupal 8 and [composer_manager](https://drupal.org/project/composer_manager).
+1. Install the -dev versions of Drupal 8 and [composer_manager](https://drupal.org/project/composer_manager).
 2. Initialize composer_manager* (`drush composer-manager-init` or `php modules/composer_manager/scripts/init.sh`).
+3. Download [inline_entity_form](https://github.com/webflo/inline_entity_form.git) to your modules directory.
 
 With Drush:
 


### PR DESCRIPTION
Because the 8.x branch of Inline_entity_form does not live on Drupal.org it needs to be installed manually from Github.
