### PR TITLE
Add Product and Line Item Inline entity form handlers

### DIFF
--- a/modules/line_item/src/Entity/LineItem.php
+++ b/modules/line_item/src/Entity/LineItem.php
@@ -27,7 +27,8 @@ use Drupal\user\UserInterface;
  *       "add" = "Drupal\commerce_line_item\Form\LineItemForm",
  *       "edit" = "Drupal\commerce_line_item\Form\LineItemForm",
  *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm"
- *     }
+ *     },
+ *     "inline entity form" = "Drupal\commerce_line_item\Form\LineItemInlineEntityFormHandler",
  *   },
  *   base_table = "commerce_line_item",
  *   admin_permission = "administer line items",

--- a/modules/line_item/src/Form/LineItemInlineEntityFormHandler.php
+++ b/modules/line_item/src/Form/LineItemInlineEntityFormHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Defines the inline entity form controller for Commerce Line Items.
+ */
+
+namespace Drupal\commerce_line_item\Form;
+use Drupal\inline_entity_form\InlineEntityForm\EntityInlineEntityFormHandler;
+
+/**
+ * Commerce line item inline entity form handler.
+ */
+class LineItemInlineEntityFormHandler extends EntityInlineEntityFormHandler {
+
+}

--- a/modules/product/src/Entity/Product.php
+++ b/modules/product/src/Entity/Product.php
@@ -32,6 +32,7 @@ use Drupal\user\UserInterface;
  *       "edit" = "Drupal\commerce_product\Form\ProductForm",
  *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm"
  *     },
+ *     "inline entity form" = "Drupal\commerce_product\Form\ProductInlineEntityFormHandler",
  *     "translation" = "Drupal\content_translation\ContentTranslationHandler"
  *   },
  *   admin_permission = "administer products",

--- a/modules/product/src/Form/ProductInlineEntityFormHandler.php
+++ b/modules/product/src/Form/ProductInlineEntityFormHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Contains \Drupal\commerce_product\Form\ProductInlineEntityFormHandler.
+ */
+
+namespace Drupal\commerce_product\Form;
+
+use Drupal\inline_entity_form\InlineEntityForm\EntityInlineEntityFormHandler;
+
+/**
+ * Commerce product inline entity form handler.
+ */
+class ProductInlineEntityFormHandler extends EntityInlineEntityFormHandler {
+
+}


### PR DESCRIPTION
Add inline entity form for Product and Line Item entities.

For the moment, handlers are empty so default configuration is used.

I'm not sure it's useful for Line Item since the only way to create them is with inline_entity_form in orders (so we can have logical in default form).

But this can be useful to define specific stuff for products.
