### PR TITLE
Now that inline_entity_form is on drupal.org, we can remove the clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,7 @@ before_script:
   - composer drupal-rebuild
   - composer update --prefer-source -n --verbose
   - cd ..
-  # Remove this one inline_entity_form is on drupal.org
-  - git clone https://github.com/webflo/inline_entity_form.git modules/inline_entity_form
+  - drush dl inline_entity_form
   - drush en -y commerce commerce_product commerce_order
 
 script:


### PR DESCRIPTION
Thanks to their migration across to drupal.org, a clone is no longer needed! Yay!
