### PR TITLE
Enable default currency based on country on install commerce_price

### DIFF
--- a/modules/price/commerce_price.install
+++ b/modules/price/commerce_price.install
@@ -6,16 +6,20 @@
  * Import the default currencies from the library.
  */
 function commerce_price_install() {
+  $currency_code = "USD";
+  // If the default country has been set, detect currency_code.
+  $default_country = \Drupal::config('system.date')->get('country.default');
+  if($default_country){
+    $countryRepository = new \CommerceGuys\Intl\Country\CountryRepository();
+    $currency_code = $countryRepository->get($default_country)->getCurrencyCode();
+  }
+
   /** @var \Drupal\commerce_price\CurrencyImporterInterface $currency_importer */
   $currency_importer = \Drupal::service('commerce_price.currency_importer');
-  // A list of currencies to import and enable by default.
-  $preloaded_currencies = ['USD', 'EUR', 'GBP'];
 
-  foreach ($preloaded_currencies as $currency_code) {
-    $entity = $currency_importer->importCurrency($currency_code);
-    if ($entity) {
-      $entity->save();
-    }
+  $entity = $currency_importer->importCurrency($currency_code);
+  if ($entity) {
+    $entity->save();
   }
 
   // Import default number formats.


### PR DESCRIPTION
On enabling the commerce_price module, this will enable the currency for the default country.
If no default country has been set, USD will be used.
