### PR TITLE
Consider to use lionsad/drupal_ti

### DIFF
--- a/.travis-before-script.sh
+++ b/.travis-before-script.sh
@@ -17,6 +17,7 @@ cd "$DRUPAL_TI_DRUPAL_DIR"
 
 	git clone --branch 8.x-1.x http://git.drupal.org/project/composer_manager.git
 	git clone --branch 8.x-1.x http://git.drupal.org/project/address.git
+	git clone --branch 8.x-1.x http://git.drupal.org/project/inline_entity_form.git
 )
 
 # Enable and run composer_manager.
@@ -33,9 +34,6 @@ rm -rf vendor
 composer drupal-rebuild
 composer update --prefer-source -n --verbose
 cd ..
-
-# Download more dependencies.
-drush dl -y inline_entity_form
 
 # Enable main module and submodules.
 drush en -y commerce commerce_product commerce_order

--- a/.travis-before-script.sh
+++ b/.travis-before-script.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e $DRUPAL_TI_DEBUG
+
+# Ensure the right Drupal version is installed.
+# Note: This function is re-entrant.
+drupal_ti_ensure_drupal
+
+# Add custom modules to drupal build.
+cd "$DRUPAL_TI_DRUPAL_DIR"
+
+# Download custom branches of address and composer_manager.
+(
+	# These variables come from environments/drupal-*.sh
+	mkdir -p "$DRUPAL_TI_MODULES_PATH"
+	cd "$DRUPAL_TI_MODULES_PATH"
+
+	git clone --branch 8.x-1.x http://git.drupal.org/project/composer_manager.git
+	git clone --branch 8.x-1.x http://git.drupal.org/project/address.git
+)
+
+# Enable and run composer_manager.
+drush pm-enable composer_manager --yes
+drush composer-manager-init
+
+# Ensure the module is linked into the codebase.
+drupal_ti_ensure_module_linked
+
+# Rebuild core dependencies.
+# @todo Is that really needed?
+cd core
+rm -rf vendor
+composer drupal-rebuild
+composer update --prefer-source -n --verbose
+cd ..
+
+# Download more dependencies.
+drush dl -y inline_entity_form
+
+# Enable main module and submodules.
+drush en -y commerce commerce_product commerce_order

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,100 +1,117 @@
+# @file
+# .travis.yml - Drupal for Travis CI Integration
+#
+# Template provided by https://github.com/LionsAd/drupal_ti.
+#
+# Based for simpletest upon:
+#   https://github.com/sonnym/travis-ci-drupal-module-example
+
 language: php
-cache:
-  bundler: true
-  directories:
-    - $HOME/tmp/drush
-    - $HOME/.bundle
-  apt: true
+
+sudo: false
 
 php:
   - 5.5
   - 5.6
+  - 7
+  - hhvm
+
+branches:
+  only:
+    - "8.x-2.x"
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: hhvm
+    - php: 7
+
+env:
+  global:
+    # add composer's global bin directory to the path
+    # see: https://github.com/drush-ops/drush#install---composer
+    - PATH="$PATH:$HOME/.composer/vendor/bin"
+
+    # Configuration variables.
+    - DRUPAL_TI_MODULE_NAME="commerce"
+    - DRUPAL_TI_SIMPLETEST_GROUP="commerce"
+
+    # Define runners and environment vars to include before and after the
+    # main runners / environment vars.
+    #- DRUPAL_TI_SCRIPT_DIR_BEFORE="./drupal_ti/before"
+    #- DRUPAL_TI_SCRIPT_DIR_AFTER="./drupal_ti/after"
+
+    # The environment to use, supported are: drupal-7, drupal-8
+    - DRUPAL_TI_ENVIRONMENT="drupal-8"
+
+    # Drupal specific variables.
+    - DRUPAL_TI_DB="drupal_travis_db"
+    - DRUPAL_TI_DB_URL="mysql://root:@127.0.0.1/drupal_travis_db"
+    # Note: Do not add a trailing slash here.
+    - DRUPAL_TI_WEBSERVER_URL="http://127.0.0.1"
+    - DRUPAL_TI_WEBSERVER_PORT="8080"
+
+    # Simpletest specific commandline arguments, the DRUPAL_TI_SIMPLETEST_GROUP is appended at the end.
+    - DRUPAL_TI_SIMPLETEST_ARGS="--verbose --color --concurrency 4 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT"
+
+    # === Behat specific variables.
+    # This is relative to $TRAVIS_BUILD_DIR
+    - DRUPAL_TI_BEHAT_DIR="./tests/behat"
+    # These arguments are passed to the bin/behat command.
+    - DRUPAL_TI_BEHAT_ARGS=""
+    # Specify the filename of the behat.yml with the $DRUPAL_TI_DRUPAL_DIR variables.
+    - DRUPAL_TI_BEHAT_YML="behat.yml.dist"
+    # This is used to setup Xvfb.
+    - DRUPAL_TI_BEHAT_SCREENSIZE_COLOR="1280x1024x16"
+    # The version of selenium that should be used.
+    - DRUPAL_TI_BEHAT_SELENIUM_VERSION="2.44"
+    # Set DRUPAL_TI_BEHAT_DRIVER to "selenium" to use "firefox" or "chrome" here.
+    - DRUPAL_TI_BEHAT_DRIVER="phantomjs"
+    - DRUPAL_TI_BEHAT_BROWSER="firefox"
+
+    # PHPUnit specific commandline arguments.
+    - DRUPAL_TI_PHPUNIT_ARGS=""
+
+    # Code coverage via coveralls.io
+    - DRUPAL_TI_COVERAGE="satooshi/php-coveralls:0.6.*"
+    # This needs to match your .coveralls.yml file.
+    - DRUPAL_TI_COVERAGE_FILE="build/logs/clover.xml"
+
+    # Debug options
+    #- DRUPAL_TI_DEBUG="-x -v"
+    # Set to "all" to output all files, set to e.g. "xvfb selenium" or "selenium",
+    # etc. to only output those channels.
+    #- DRUPAL_TI_DEBUG_FILE_OUTPUT="selenium xvfb webserver"
+
+  matrix:
+    # [[[ SELECT ANY OR MORE OPTIONS ]]]
+    #- DRUPAL_TI_RUNNERS="phpunit"
+    - DRUPAL_TI_RUNNERS="simpletest"
+    #- DRUPAL_TI_RUNNERS="behat"
+    #- DRUPAL_TI_RUNNERS="phpunit simpletest behat"
 
 mysql:
-  database: drupal
+  database: drupal_travis_db
   username: root
   encoding: utf8
 
+before_install:
+  - composer self-update
+  - composer global require "lionsad/drupal_ti:1.*"
+  - drupal-ti before_install
+
 install:
-  - "mysql -e 'create database drupal;'"
-
-  # Install latest Drush 7.
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - travis_retry composer self-update
-  - travis_retry composer global require --no-interaction --prefer-source drush/drush:dev-master
-
-  # Make sure we don't fail when checking out projects
-  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-
-  # LAMP package installation (mysql is already started)
-  - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
-
-  # enable php-fpm, travis does not support any other method with php and apache
-  - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fastcgi alias
-  - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
-
-  # Make sure the apache root is in our wanted directory
-  - echo "$(curl -fsSL https://gist.githubusercontent.com/nickveenhof/11386315/raw/b8abaf9304fe12b5cc7752d39c29c1edae8ac2e6/gistfile1.txt)" | sed -e "s,PATH,$TRAVIS_BUILD_DIR/../drupal,g" | sudo tee /etc/apache2/sites-available/default > /dev/null
-
-  # Disable sendmail.
-  - echo sendmail_path=`which true` >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-
-  # Forward the errors to the syslog so we can print them
-  - echo "error_log=syslog" >> `php --ini | grep "Loaded Configuration" | awk '{print $4}'`
-
-
-  # Build Codebase.
-  - TESTDIR=$(pwd)
-  - cd ..
-  - git clone --branch 8.0.x --depth 1 http://git.drupal.org/project/drupal.git drupal
-  - git clone --branch 8.x-1.x http://git.drupal.org/project/composer_manager.git drupal/modules/composer_manager
-  - git clone --branch 8.x-1.x http://git.drupal.org/project/address.git drupal/modules/address
-  - git clone --branch 8.x-1.x http://git.drupal.org/project/inline_entity_form.git drupal/modules/inline_entity_form
-  - cd drupal
-  - wget https://www.drupal.org/files/issues/2189345-61.patch
-  - git apply -v -p1 < 2189345-61.patch
-
-  # Restart apache and test it
-  - sudo service apache2 restart
-  - curl -v "http://localhost"
+  - drupal-ti install
 
 before_script:
-  - ln -s $TESTDIR modules/commerce
-  # Mysql might time out for long tests, increase the wait timeout.
-  - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
-  # Update drupal core
-  - git pull origin 8.0.x
-  - drush si --db-url=mysql://root:@127.0.0.1/drupal --account-name=admin --account-pass=admin --site-mail=admin@example.com --site-name="Commerce" --yes
-  - drush en -y composer_manager simpletest
-  - drush composer-manager-init
-  - cd core
-  - rm -rf vendor
-  - composer drupal-rebuild
-  - travis_retry composer update --prefer-source -n --verbose
-  - cd ..
-  - drush en -y commerce commerce_product commerce_order
+  - drupal-ti --include ".travis-before-script.sh"
+  - drupal-ti before_script
 
 script:
-  # Run the tests
-  - php core/scripts/run-tests.sh --verbose --color --concurrency 4 --php `which php` --url http://localhost "commerce" | tee /tmp/test.txt; TEST_EXIT=${PIPESTATUS[0]}; echo $TEST_EXIT
-  # Check if we had fails in the run-tests.sh script
-  # Exit with the inverted value, because if there are no fails found, it will exit with 1 and for us that\
-  # is a good thing so invert it to 0. Travis has some issues with the exclamation mark in front so we have to fiddle a
-  # bit.
-  # Also make the grep case insensitive and fail on run-tests.sh regular fails as well on fatal errors.
-  - TEST_OUTPUT=$(! egrep -i "([0-9]+ fails)|(PHP Fatal error)|([0-9]+ exceptions)" /tmp/test.txt > /dev/null)$?
-  - echo $TEST_OUTPUT
-  # if the TEST_EXIT status is 0 AND the TEST_OUTPUT status is also 0 it means we succeeded, in all other cases we
-  # failed.
-  # Re-enable when trying to get CodeSniffer doesn't return a 403 anymore.
-  #- /home/travis/.composer/vendor/bin/phpcs --standard=/home/travis/.composer/vendor/drupal/coder/coder_sniffer/Drupal --extensions=php,inc,test,module,install --ignore=css/ $TRAVIS_BUILD_DIR/../drupal/modules/search_api
-  - php -i | grep 'php.ini'
-  - sudo cat /var/log/apache2/error.log
+  - drupal-ti script
 
-  #  Enable once PHPUnit tests are in Commerce
-  #  - cd $TRAVIS_BUILD_DIR/../drupal/core
-  #  - ./vendor/bin/phpunit --verbose --debug ../modules/commerce/; TEST_PHPUNIT=$?; echo $TEST_PHPUNIT
-  #  - if [ $TEST_EXIT -eq 0 ] && [ $TEST_OUTPUT -eq 0 ] && [ $TEST_PHPUNIT -eq 0 ]; then exit 0; else exit 1; fi
+after_script:
+  - drupal-ti after_script
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,10 @@ env:
 
     # PHPUnit specific commandline arguments.
     - DRUPAL_TI_PHPUNIT_ARGS=""
+    # Specifying the phpunit-core src/ directory is useful when e.g. a vendor/
+    # directory is present in the module directory, which phpunit would then
+    # try to find tests in. This option is relative to $TRAVIS_BUILD_DIR.
+    #- DRUPAL_TI_PHPUNIT_CORE_SRC_DIRECTORY="./tests/src"
 
     # Code coverage via coveralls.io
     - DRUPAL_TI_COVERAGE="satooshi/php-coveralls:0.6.*"
@@ -86,7 +90,7 @@ env:
   matrix:
     # [[[ SELECT ANY OR MORE OPTIONS ]]]
     #- DRUPAL_TI_RUNNERS="phpunit"
-    - DRUPAL_TI_RUNNERS="simpletest"
+    - DRUPAL_TI_RUNNERS="phpunit-core simpletest"
     #- DRUPAL_TI_RUNNERS="behat"
     #- DRUPAL_TI_RUNNERS="phpunit simpletest behat"
 


### PR DESCRIPTION
Hello,

This is a test PR to see if drupal_ti would work for commerce.

drupal_ti wants to be a generic solution to empower D7 and D8 modules to enable automated testing without having to deal with all the setup of travis-ci. (especially hhvm and PHP 5.3 had been difficult to support for the docker containers)

phpunit, simpletest, behat is all supported with various browsers (chrome / firefox on selenium) and drivers ( selenium / goutte / phantomjs).

drupal_ti itself is tested on travis for all possible combinations

Running phpunit tests as part of Drupal 8 core is supported, though right now needs some custom code. (e.g. https://github.com/md-systems/pathauto/pull/51/files) That will be incorporated into the code base soon in the 1.3 branch. Given commerce does not yet have such tests that is probably acceptable.

Currently (in this PR) the cache has been disabled, but drupal_ti supports an advanced caching layer in dev-master (will be in 1.4.0), hence I would do that separately.
