### PR TITLE
Entity link templates should be paths

### DIFF
--- a/modules/payment/src/Entity/PaymentTransaction.php
+++ b/modules/payment/src/Entity/PaymentTransaction.php
@@ -39,8 +39,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *   permission_granularity = "bundle",
  *   admin_permission = "administer payment transactions",
  *   links = {
- *     "edit-form" = "entity.commerce_payment_transaction.edit_form",
- *     "delete-form" = "entity.commerce_payment_transaction.delete_form"
+ *     "edit-form" = "/admin/commerce/config/payment-info-types/{commerce_payment_info_type}/edit",
+ *     "delete-form" = "/admin/commerce/config/payment-info-types/{commerce_payment_info_type}/delete"
  *   },
  * )
  */


### PR DESCRIPTION
Entity link templates should be paths instead of route names, and Drupal throws fatal errors if that's not the case.

At the moment, if anyone enables the Commerce Payment module (just to see what's the current state), they put their Drupal installation in an unusable state. The fatal errors even prevent the module from being uninstalled.
