### PR TITLE
Issue #2574759 by iMiksu: Fixed tax type validation error on empty tag

### DIFF
--- a/modules/tax/src/Form/TaxTypeForm.php
+++ b/modules/tax/src/Form/TaxTypeForm.php
@@ -126,7 +126,7 @@ class TaxTypeForm extends EntityForm {
    */
   public function validateTag(array $element, FormStateInterface $form_state, array $form) {
     $tag = $element['#value'];
-    if (!preg_match('/[a-zA-Z0-9]+/', $tag)) {
+    if (!empty($tag) && !preg_match('/[a-zA-Z0-9]+/', $tag)) {
       $form_state->setError($element, $this->t('The tag must be a single word.'));
     }
   }


### PR DESCRIPTION
Fixes issue where tax type were not able to be created when no having tag defined at all.

Drupal.org issue: https://www.drupal.org/node/2574759
