### PR TITLE
Issue #2574605 Make lineitem type as a target configurable on the product type configuration form

### DIFF
--- a/modules/order/src/Form/LineItemTypeForm.php
+++ b/modules/order/src/Form/LineItemTypeForm.php
@@ -82,6 +82,8 @@ class LineItemTypeForm extends EntityForm {
       '#default_value' => $lineItemType->getPurchasableEntityType(),
       '#options' => $purchasableEntityTypes,
       '#empty_value' => '',
+      '#disabled' => !$lineItemType->isNew(),
+      '#required' => TRUE,
     ];
     $form['orderType'] = [
       '#type' => 'select',

--- a/modules/product/config/schema/commerce_product.schema.yml
+++ b/modules/product/config/schema/commerce_product.schema.yml
@@ -28,6 +28,9 @@ commerce_product.commerce_product_variation_type.*:
     label:
       type: label
       label: 'Label'
+    lineItemType:
+      type: string
+      label: 'Line item type'
 
 field.field.*.*.*.third_party.commerce_product:
   type: mapping

--- a/modules/product/src/Entity/ProductVariation.php
+++ b/modules/product/src/Entity/ProductVariation.php
@@ -163,6 +163,21 @@ class ProductVariation extends ContentEntityBase implements ProductVariationInte
   /**
    * {@inheritdoc}
    */
+  public function getLineItemType() {
+    // Get the variationType entity based on the variation type value.
+    $variationType = $this->entityManager()
+      ->getStorage('commerce_product_variation_type')
+      ->load($this->type);
+
+    // Get the lineItemType value from the variation type entity.
+    $lineItemType = $variationType->getLineItemType();
+
+    return $lineItemType;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function baseFieldDefinitions(EntityTypeInterface $entityType) {
     $fields['variation_id'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Variation ID'))

--- a/modules/product/src/Entity/ProductVariationType.php
+++ b/modules/product/src/Entity/ProductVariationType.php
@@ -34,6 +34,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *   config_export = {
  *     "id",
  *     "label",
+ *     "lineItemType",
  *   },
  *   links = {
  *     "edit-form" =   "/admin/commerce/config/product-variation-types/{commerce_product_variation_type}/edit",
@@ -50,5 +51,27 @@ class ProductVariationType extends ConfigEntityBundleBase implements ProductVari
    * @var string
    */
   protected $id;
+
+  /**
+   * The line item type.
+   *
+   * @var string
+   */
+  protected $lineItemType;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLineItemType() {
+    return $this->lineItemType;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setLineItemType($lineItemType) {
+    $this->lineItemType = $lineItemType;
+    return $this;
+  }
 
 }

--- a/modules/product/src/Entity/ProductVariationTypeInterface.php
+++ b/modules/product/src/Entity/ProductVariationTypeInterface.php
@@ -13,4 +13,25 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
  * Defines the interface for product variation types.
  */
 interface ProductVariationTypeInterface extends ConfigEntityInterface {
+
+  /**
+   * Gets the product variation type's line item type.
+   *
+   * Used for finding/creating the appropriate line item when purchasing a
+   * product (adding it to an order).
+   *
+   * @return string
+   *   The line item type.
+   */
+  public function getLineItemType();
+
+  /**
+   * Sets the product variation type's line item type.
+   *
+   * @param string $lineItemType
+   *   The line item type.
+   *
+   * @return $this
+   */
+  public function setLineItemType($lineItemType);
 }

--- a/modules/product/src/Form/ProductVariationForm.php
+++ b/modules/product/src/Form/ProductVariationForm.php
@@ -14,5 +14,4 @@ use Drupal\Core\Form\FormStateInterface;
  * Form controller for the product variation edit form.
  */
 class ProductVariationForm extends ContentEntityForm {
-
 }

--- a/modules/product/src/Form/ProductVariationTypeForm.php
+++ b/modules/product/src/Form/ProductVariationTypeForm.php
@@ -35,6 +35,32 @@ class ProductVariationTypeForm extends EntityForm {
       '#disabled' => !$variationType->isNew(),
     ];
 
+    if (\Drupal::moduleHandler()->moduleExists('commerce_order')) {
+
+      // Prepare the list of line item types.
+      $lineItemTypes = $this->entityManager->getStorage('commerce_line_item_type')
+        ->loadMultiple();
+
+      // We want to filter out all line item types that are not meant for
+      // commerce product variations entity bundles.
+      $lineItemTypes = array_filter($lineItemTypes, function($lineItemType) {
+        return $lineItemType->getPurchasableEntityType() == 'commerce_product_variation';
+      });
+
+      $lineItemTypes = array_map(function ($lineItemType) {
+        return $lineItemType->label();
+      }, $lineItemTypes);
+
+      $form['lineItemType'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Line item type'),
+        '#default_value' => $variationType->getLineItemType(),
+        '#options' => $lineItemTypes,
+        '#empty_value' => '',
+        '#required' => TRUE,
+      ];
+    }
+
     return $form;
   }
 

--- a/src/PurchasableEntityInterface.php
+++ b/src/PurchasableEntityInterface.php
@@ -17,4 +17,15 @@ use Drupal\Core\Entity\ContentEntityInterface;
  * on commerce_order.
  */
 interface PurchasableEntityInterface extends ContentEntityInterface {
+
+  /**
+   * Gets the purchasable entity type's line item type.
+   *
+   * Used for finding/creating the appropriate line item when purchasing a
+   * product (adding it to an order).
+   *
+   * @return string
+   *   The line item type.
+   */
+  function getLineItemType();
 }


### PR DESCRIPTION
Adds line item type select to commerce variation type configuration.

https://www.drupal.org/node/2574605
