### PR TITLE
Remove old FieldDefinition import

### DIFF
--- a/modules/tax/commerce_tax.module
+++ b/modules/tax/commerce_tax.module
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Field\FieldDefinition;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 


### PR DESCRIPTION
It was renamed to BaseFieldDefinition a year ago, and the import was left over.
