### PR TITLE
Issue #2574793: Tax rate machine name was not able to be changed if default

### DIFF
--- a/modules/tax/src/Form/TaxRateForm.php
+++ b/modules/tax/src/Form/TaxRateForm.php
@@ -8,6 +8,7 @@
 namespace Drupal\commerce_tax\Form;
 
 use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -27,6 +28,13 @@ class TaxRateForm extends EntityForm {
    * @var \Drupal\Core\Entity\EntityStorageInterface
    */
   protected $taxTypeStorage;
+
+  /**
+   * The original tax rate configuration entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $originalTaxRate;
 
   /**
    * Creates a TaxRateForm instance.
@@ -57,6 +65,10 @@ class TaxRateForm extends EntityForm {
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
     $taxRate = $this->entity;
+
+    // Store tax rate while building the form, so that we may fetch original
+    // values from it while validating. @see self::validateDefault()
+    $this->setOriginalTaxRate($taxRate);
 
     $form['type'] = [
       '#type' => 'hidden',
@@ -117,14 +129,15 @@ class TaxRateForm extends EntityForm {
    * Validates that there is only one default per tax type.
    */
   public function validateDefault(array $element, FormStateInterface $form_state, array $form) {
-    $taxRate = $this->getEntity();
+    $originalTaxRate = $this->getOriginalTaxRate();
     $default = $element['#value'];
+
     if ($default) {
       $loadedTaxRates = $this->taxRateStorage->loadByProperties([
         'type' => $form_state->getValue('type'),
       ]);
       foreach ($loadedTaxRates as $rate) {
-        if ($rate->getId() !== $taxRate->getId() && $rate->isDefault()) {
+        if ($rate->getId() !== $originalTaxRate->getId() && $rate->isDefault()) {
           $form_state->setError($element, $this->t('Tax rate %label is already the default.', [
             '%label' => $rate->label(),
           ]));
@@ -173,6 +186,25 @@ class TaxRateForm extends EntityForm {
       $this->logger('commerce_tax')->error($e);
       $form_state->setRebuild();
     }
+  }
+
+  /**
+   * Sets the original tax rate configuration entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   * @return void
+   */
+  protected function setOriginalTaxRate(EntityInterface $entity) {
+    $this->originalTaxRate = $entity;
+  }
+
+  /**
+   * Fetches the original tax type.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   */
+  protected function getOriginalTaxRate() {
+    return $this->originalTaxRate;
   }
 
 }


### PR DESCRIPTION
## Problem

See validation for "Default" field:

``` php
  /**
   * Validates that there is only one default per tax type.
   */
  public function validateDefault(array $element, FormStateInterface $form_state, array $form) {
    $taxRate = $this->getEntity();
    $default = $element['#value'];
    if ($default) {
      $loadedTaxRates = $this->taxRateStorage->loadByProperties([
        'type' => $form_state->getValue('type'),
      ]);
      foreach ($loadedTaxRates as $rate) {
        if ($rate->getId() !== $taxRate->getId() && $rate->isDefault()) {
          $form_state->setError($element, $this->t('Tax rate %label is already the default.', [
            '%label' => $rate->label(),
          ]));
          break;
        }
      }
    }
  }
```

We can see, that there is already an valid condition for this, but it turns out that entity gets updated prior to form validation in `\Drupal\Core\Form\FormBuilder::processForm()`.

See how `doBuildForm()` method gets called before `validateForm()` in http://cgit.drupalcode.org/drupal/tree/core/lib/Drupal/Core/Form/FormBuilder.php#n537
## Proposed solution

I tried XDebug original entity or values from `$form_state` and tried to seek for any type of `originalEntity` traits or something without success.

I ended up implementing `TaxRateForm::originalTaxRate` property with getter and setter methods and populate it on form build, and use its value in the validation.
