### PR TITLE
Return the cache contexts from price formatters, issue 2571395

### DIFF
--- a/modules/price/src/Plugin/Field/FieldFormatter/PriceDefaultFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PriceDefaultFormatter.php
@@ -141,6 +141,12 @@ class PriceDefaultFormatter extends FormatterBase implements ContainerFactoryPlu
       $currency = $currencies[$item->currency_code];
       $elements[$delta] = [
         '#markup' => $this->numberFormatter->formatCurrency($item->amount, $currency),
+        '#cache' => [
+          'contexts' => [
+            'languages:' . LanguageInterface::TYPE_INTERFACE,
+            'country',
+          ],
+        ],
       ];
     }
 

--- a/modules/price/src/Plugin/Field/FieldFormatter/PricePlainFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PricePlainFormatter.php
@@ -92,6 +92,12 @@ class PricePlainFormatter extends FormatterBase implements ContainerFactoryPlugi
         '#theme' => 'commerce_price_plain',
         '#amount' => $item->amount,
         '#currency' => $currencies[$item->currency_code],
+        '#cache' => [
+          'contexts' => [
+            'languages:' . LanguageInterface::TYPE_INTERFACE,
+            'country',
+          ],
+        ],
       ];
     }
 


### PR DESCRIPTION
I'm flying a bit blind here, but I _think_ this is what you were looking for.

I'm assuming I don't need to also add this to modules/price/src/Plugin/Field/FieldFormatter/PriceDefaultFormatter.php.
