### PR TITLE
Issue #2600564: Integrate profile into commerce

### DIFF
--- a/modules/order/commerce_order.info.yml
+++ b/modules/order/commerce_order.info.yml
@@ -10,6 +10,7 @@ dependencies:
   - entity_reference
   - inline_entity_form
   - options
+  - profile
 config_devel:
   - views.view.commerce_orders
   - commerce_order.commerce_order_type.default

--- a/modules/order/config/install/field.field.profile.billing.address.yml
+++ b/modules/order/config/install/field.field.profile.billing.address.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.address
+    - profile.type.billing
+  module:
+    - address
+id: profile.billing.address
+field_name: address
+entity_type: profile
+bundle: billing
+label: Address
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  available_countries: {  }
+  fields:
+    administrativeArea: administrativeArea
+    locality: locality
+    dependentLocality: dependentLocality
+    postalCode: postalCode
+    sortingCode: sortingCode
+    addressLine1: addressLine1
+    addressLine2: addressLine2
+    organization: organization
+    recipient: recipient
+  langcode_override: ''
+field_type: address

--- a/modules/order/config/install/field.field.profile.billing.address.yml
+++ b/modules/order/config/install/field.field.profile.billing.address.yml
@@ -12,7 +12,7 @@ entity_type: profile
 bundle: billing
 label: Address
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/modules/order/config/install/field.storage.profile.address.yml
+++ b/modules/order/config/install/field.storage.profile.address.yml
@@ -10,7 +10,7 @@ entity_type: profile
 type: address
 settings: {  }
 module: address
-locked: false
+locked: true
 cardinality: 1
 translatable: true
 indexes: {  }

--- a/modules/order/config/install/field.storage.profile.address.yml
+++ b/modules/order/config/install/field.storage.profile.address.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - address
+    - profile
+id: profile.address
+field_name: address
+entity_type: profile
+type: address
+settings: {  }
+module: address
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/order/config/install/profile.type.billing.yml
+++ b/modules/order/config/install/profile.type.billing.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: billing
+label: Billing
+registration: false
+multiple: false
+weight: 0

--- a/modules/order/src/Entity/Order.php
+++ b/modules/order/src/Entity/Order.php
@@ -14,6 +14,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\UserInterface;
+use Drupal\profile\Entity\ProfileInterface;
 
 /**
  * Defines the Commerce Order entity.
@@ -210,6 +211,36 @@ class Order extends ContentEntityBase implements OrderInterface {
    */
   public function setStoreId($storeId) {
     $this->set('store_id', $storeId);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBillingProfile() {
+    return $this->get('billing_profile')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setBillingProfile(ProfileInterface $profile) {
+    $this->set('billing_profile', $profile->id());
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBillingProfileId() {
+    return $this->get('billing_profile')->target_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setBillingProfileId($billingProfileId) {
+    $this->set('billing_profile', $billingProfileId);
     return $this;
   }
 
@@ -462,6 +493,22 @@ class Order extends ContentEntityBase implements OrderInterface {
     $fields['data'] = BaseFieldDefinition::create('map')
       ->setLabel(t('Data'))
       ->setDescription(t('A serialized array of additional data.'));
+
+    $fields['billing_profile'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Billing profile'))
+      ->setDescription(t('Billing profile'))
+      ->setRequired(TRUE)
+      ->setSetting('target_type', 'profile')
+      ->setSetting('handler', 'default')
+      ->setSetting('handler_settings', ['target_bundles' => ['profile']])
+      ->setTranslatable(TRUE)
+      ->setDisplayOptions('form', [
+        'type' => 'options_select',
+        'weight' => 0,
+        'settings' => [],
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
 
     return $fields;
   }

--- a/modules/order/src/Entity/OrderInterface.php
+++ b/modules/order/src/Entity/OrderInterface.php
@@ -11,6 +11,7 @@ use Drupal\commerce_store\Entity\EntityStoreInterface;
 use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\user\EntityOwnerInterface;
+use Drupal\profile\Entity\ProfileInterface;
 
 /**
  * Defines the interface for orders.
@@ -150,5 +151,41 @@ interface OrderInterface extends EntityStoreInterface, EntityChangedInterface, E
    * @return $this
    */
   public function setEmail($mail);
+
+  /**
+   * Gets the billing profile.
+   *
+   * @return \Drupal\profile\Entity\ProfileInterface
+   *   The billing profile entity.
+   */
+  public function getBillingProfile();
+
+  /**
+   * Sets the billing profile.
+   *
+   * @param \Drupal\profile\Entity\ProfileInterface $profile
+   *   The billing profile entity.
+   *
+   * @return $this
+   */
+  public function setBillingProfile(ProfileInterface $profile);
+
+  /**
+   * Gets the billing profile id.
+   *
+   * @return int
+   *   The billing profile id.
+   */
+  public function getBillingProfileId();
+
+  /**
+   * Sets the billing profile id.
+   *
+   * @param int $billingProfileId
+   *   The billing profile id.
+   *
+   * @return $this
+   */
+  public function setBillingProfileId($billingProfileId);
 
 }


### PR DESCRIPTION
This will cover:
- Add the profile module dependency to order
- Create the “billing” profile bundle and export it to order/config/install
- Create the "address" field on the "billing" profile and export it to order/config/install
- Create a billing_profile reference field on the order (base field definition), add a getter and a setter
