### PR TITLE
EntityBundle views handler

### DIFF
--- a/commerce.views.inc
+++ b/commerce.views.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function commerce_views_data_alter(array &$data) {
+  // Override the default bundle views field handler.
+  $entity_types = \Drupal::service('entity_type.manager')->getDefinitions();
+  foreach ($entity_types as $entity_type) {
+    // Only override for commerce content entities.
+    if ($entity_type instanceof \Drupal\Core\Entity\ContentEntityType && strpos($entity_type->id(), 'commerce_') === 0) {
+      // Bundle is stored either in the data or the base table.
+      if (!empty($data[$entity_type->getDataTable()])) {
+        $data[$entity_type->getDataTable()][$entity_type->getKey('bundle')]['field']['id'] = 'entity_bundle';
+      }
+      else {
+        $data[$entity_type->getBaseTable()][$entity_type->getKey('bundle')]['field']['id'] = 'entity_bundle';
+      }
+    }
+  }
+}

--- a/config/schema/commerce.views.field.schema.yml
+++ b/config/schema/commerce.views.field.schema.yml
@@ -1,0 +1,8 @@
+# Schema for the views plugins of the Commerce module.
+
+views.field.entity_bundle:
+  type: views.field.field
+  mapping:
+    hide_single_bundle:
+      type: boolean
+      label: 'Hide if there''s only one bundle.'

--- a/modules/product/config/install/views.view.commerce_products.yml
+++ b/modules/product/config/install/views.view.commerce_products.yml
@@ -95,7 +95,7 @@ display:
               default_sort_order: asc
               align: ''
               separator: ''
-              empty_column: false
+              empty_column: true
               responsive: ''
             status:
               sortable: true
@@ -250,9 +250,10 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          hide_single_bundle: true
           entity_type: commerce_product
           entity_field: type
-          plugin_id: field
+          plugin_id: entity_bundle
         status:
           id: status
           table: commerce_product_field_data

--- a/modules/store/config/install/views.view.commerce_stores.yml
+++ b/modules/store/config/install/views.view.commerce_stores.yml
@@ -93,7 +93,7 @@ display:
               default_sort_order: asc
               align: ''
               separator: ''
-              empty_column: false
+              empty_column: true
               responsive: ''
             operations:
               sortable: false
@@ -234,9 +234,10 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          hide_single_bundle: true
           entity_type: commerce_store
           entity_field: type
-          plugin_id: field
+          plugin_id: entity_bundle
         operations:
           id: operations
           table: commerce_store

--- a/src/Plugin/views/field/EntityBundle.php
+++ b/src/Plugin/views/field/EntityBundle.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\commerce\Plugin\views\field\EntityBundle.
+ */
+
+namespace Drupal\commerce\Plugin\views\field;
+
+use Drupal\views\Plugin\views\field\Field;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Field\FieldTypePluginManagerInterface;
+use Drupal\Core\Field\FormatterPluginManager;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+
+/**
+ * Displays the entity bundle.
+ *
+ * Can be configured to show nothing when there's only one possible bundle,
+ * allowing the 'Hide empty column' table setting to hide the column.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("entity_bundle")
+ */
+class EntityBundle extends Field {
+
+  /**
+   * The entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
+   * Constructs a \Drupal\commerce\Plugin\views\field\EntityBundle object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   *   The field formatter plugin manager.
+   * @param \Drupal\Core\Field\FormatterPluginManager $formatter_plugin_manager
+   *   The field formatter plugin manager.
+   * @param \Drupal\Core\Field\FieldTypePluginManagerInterface $field_type_plugin_manager
+   *   The field plugin type manager.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer.
+   *  @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entityTypeBundleInfo
+   *    The entity type bundle info.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityManagerInterface $entity_manager, FormatterPluginManager $formatter_plugin_manager, FieldTypePluginManagerInterface $field_type_plugin_manager, LanguageManagerInterface $language_manager, RendererInterface $renderer, EntityTypeBundleInfoInterface $entityTypeBundleInfo) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_manager, $formatter_plugin_manager, $field_type_plugin_manager, $language_manager, $renderer);
+    $this->entityTypeBundleInfo = $entityTypeBundleInfo;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity.manager'),
+      $container->get('plugin.manager.field.formatter'),
+      $container->get('plugin.manager.field.field_type'),
+      $container->get('language_manager'),
+      $container->get('renderer'),
+      $container->get('entity_type.bundle.info')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['hide_single_bundle'] = ['default' => TRUE];
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+
+    // Option to hide the bundle name if there's only one bundle.
+    $form['hide_single_bundle'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Hide if there\'s only one bundle.'),
+      '#default_value' => $this->options['hide_single_bundle'],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function renderItems($items) {
+    if ($this->options['hide_single_bundle']) {
+      $entity_type = $this->getEntityType();
+      $bundles = $this->entityTypeBundleInfo->getBundleInfo($entity_type);
+      // Hide bundle name if there's only one bundle.
+      if (count($bundles) == 1) {
+        return '';
+      }
+    }
+    return parent::renderItems($items);
+  }
+
+}


### PR DESCRIPTION
https://www.drupal.org/node/2616450

The EntityBundle views field handler is available for every ContentEntity. The handler displays the bundle name if there are more than one bundles for that entity. If there's only one bundle then it displays nothing. 
