### PR TITLE
Taxonomy reference field needs a vocabulary in test

### DIFF
--- a/modules/product/src/Tests/ProductVariationTypeTest.php
+++ b/modules/product/src/Tests/ProductVariationTypeTest.php
@@ -8,6 +8,7 @@
 namespace Drupal\commerce_product\Tests;
 
 use Drupal\commerce_product\Entity\ProductVariationType;
+use Drupal\Component\Utility\Unicode;
 
 /**
  * Ensure the product variation type works correctly.
@@ -114,16 +115,26 @@ class ProductVariationTypeTest extends ProductTestBase {
     // The edit form fails validation if target_bundles is empty.
     $this->createEntityReferenceField('commerce_product_variation', 'foo', 'field_attribute', 'Attribute', 'taxonomy_term', 'default', ['target_bundles' => ['taxonomy_term']]);
 
+    // Create a vocabulary otherwise we can't submit the field settings form.
+    $vocabulary = entity_create('taxonomy_vocabulary', array(
+      'name' => $this->randomMachineName(),
+      'description' => $this->randomMachineName(),
+      'vid' => Unicode::strtolower($this->randomMachineName()),
+    ));
+    $vocabulary->save();
+
     $edit = [
       'attribute_field' => 1,
       'attribute_widget' => 'select',
-      'attribute_widget_title' => $this->randomMachineName()
+      'attribute_widget_title' => $this->randomMachineName(),
+      'settings[handler_settings][target_bundles][' . $vocabulary->getOriginalId() . ']' => 1,
     ];
     $this->drupalPostForm('admin/commerce/config/product-variation-types/foo/edit/fields/commerce_product_variation.foo.field_attribute', $edit, t('Save settings'));
 
     $this->drupalGet('admin/commerce/config/product-variation-types/foo/edit/fields/commerce_product_variation.foo.field_attribute');
     $this->assertFieldChecked('edit-attribute-field', 'Attribute field setting is set.');
     $this->assertFieldChecked('edit-attribute-widget-select', 'Attribute widget setting field is set.');
+    $this->assertFieldChecked('edit-settings-handler-settings-target-bundles-' . $vocabulary->getOriginalId(), 'Vocabulary is selected.');
     $this->assertField('attribute_widget_title', $edit['attribute_widget_title'], 'Attribute widget title setting is set.');
   }
 


### PR DESCRIPTION
Some other tests are still failing, see other PRs for them. 
https://www.drupal.org/node/2625162
