### PR TITLE
Move the store selector to the right sidebar on the product edit form

### DIFF
--- a/modules/product/src/Form/ProductForm.php
+++ b/modules/product/src/Form/ProductForm.php
@@ -107,6 +107,17 @@ class ProductForm extends ContentEntityForm {
       '#attributes' => ['class' => ['entity-meta']],
       '#weight' => 99,
     ];
+    $form['visibility_settings'] = [
+      '#type' => 'details',
+      '#title' => t('Visibility settings'),
+      '#open' => TRUE,
+      '#group' => 'advanced',
+      '#access' => !empty($form['stores']['#access']),
+      '#attributes' => [
+        'class' => ['product-visibility-settings'],
+      ],
+      '#weight' => 30,
+    ];
     $form['path_settings'] = [
       '#type' => 'details',
       '#title' => t('URL path settings'),
@@ -119,7 +130,7 @@ class ProductForm extends ContentEntityForm {
       '#attached' => [
         'library' => ['path/drupal.path'],
       ],
-      '#weight' => 30,
+      '#weight' => 60,
     ];
     $form['author'] = [
       '#type' => 'details',
@@ -142,6 +153,9 @@ class ProductForm extends ContentEntityForm {
     }
     if (isset($form['path'])) {
       $form['path']['#group'] = 'path_settings';
+    }
+    if (isset($form['stores'])) {
+      $form['stores']['#group'] = 'visibility_settings';
     }
 
     return $form;


### PR DESCRIPTION
I've moved the store field widget to the right bar and added control to display or not the fieldset by checking the visibility of the store field widget. https://www.drupal.org/node/2626972#comment-10662764
