### PR TITLE
Replaced fulfilment by fulfillment

### DIFF
--- a/modules/order/commerce_order.workflows.yml
+++ b/modules/order/commerce_order.workflows.yml
@@ -46,10 +46,10 @@ default_validation:
       from: [draft, validation]
       to:   canceled
 
-fulfilment:
-  id: fulfilment
+fulfillment:
+  id: fulfillment
   group: order
-  label: Fulfilment
+  label: fulfillment
   states:
     draft:
       label: Draft
@@ -73,10 +73,10 @@ fulfilment:
       from: [draft, fulfillment]
       to:   canceled
 
-fulfilment_validation:
-  id: fulfilment_validation
+fulfillment_validation:
+  id: fulfillment_validation
   group: order
-  label: Fulfilment, with validation
+  label: fulfillment, with validation
   states:
     draft:
       label: Draft


### PR DESCRIPTION
Drupal is normally in American English, so we should be consistent and use fulfillment, even if it looks bad :)
