### PR TITLE
Add missing dependency on entity module for commerce_store.

### DIFF
--- a/modules/store/commerce_store.info.yml
+++ b/modules/store/commerce_store.info.yml
@@ -7,6 +7,7 @@ dependencies:
   - address
   - commerce
   - commerce_price
+  - entity
   - options
 config_devel:
   - commerce_store.commerce_store_type.default


### PR DESCRIPTION
Causes this kind of error after having enabled commerce_store.
PHP Fatal error:  Interface 'Drupal\entity\Entity\EntityDescriptionInterface' not found in /web/modules/contrib/commerce/modules/store/src/Entity/StoreTypeInterface.php on line 16
