### PR TITLE
Namespace the plugins (prepend 'commerce_').

### DIFF
--- a/commerce.views.inc
+++ b/commerce.views.inc
@@ -11,12 +11,12 @@ function commerce_views_data_alter(array &$data) {
       // Translatable entities have a data table. Non-translatable ones
       // (such as Order) have only a base table.
       if ($data_table = $entity_type->getDataTable()) {
-        $data[$data_table][$entity_type->getKey('bundle')]['field']['id'] = 'entity_bundle';
-        $data[$data_table][$entity_type->getKey('bundle')]['filter']['id'] = 'entity_bundle';
+        $data[$data_table][$entity_type->getKey('bundle')]['field']['id'] = 'commerce_entity_bundle';
+        $data[$data_table][$entity_type->getKey('bundle')]['filter']['id'] = 'commerce_entity_bundle';
       }
       else {
-        $data[$entity_type->getBaseTable()][$entity_type->getKey('bundle')]['field']['id'] = 'entity_bundle';
-        $data[$entity_type->getBaseTable()][$entity_type->getKey('bundle')]['filter']['id'] = 'entity_bundle';
+        $data[$entity_type->getBaseTable()][$entity_type->getKey('bundle')]['field']['id'] = 'commerce_entity_bundle';
+        $data[$entity_type->getBaseTable()][$entity_type->getKey('bundle')]['filter']['id'] = 'commerce_entity_bundle';
       }
     }
   }

--- a/config/schema/commerce.schema.yml
+++ b/config/schema/commerce.schema.yml
@@ -1,4 +1,4 @@
-field.widget.settings.entity_select:
+field.widget.settings.commerce_entity_select:
   type: mapping
   label: 'Entity select widget settings'
   mapping:
@@ -12,14 +12,14 @@ field.widget.settings.entity_select:
       type: string
       label: 'Autocomplete placeholder'
 
-views.field.entity_bundle:
+views.field.commerce_entity_bundle:
   type: views.field.field
   mapping:
     hide_single_bundle:
       type: boolean
       label: 'Hide if there''s only one bundle.'
 
-views.filter.entity_bundle:
+views.filter.commerce_entity_bundle:
   type: views.filter.in_operator
   label: 'Bundle'
   mapping:

--- a/modules/cart/commerce_cart.module
+++ b/modules/cart/commerce_cart.module
@@ -178,11 +178,11 @@ function commerce_cart_views_data_alter(array &$data) {
   $data['commerce_line_item']['edit_quantity']['field'] = [
     'title' => t('Quantity text field'),
     'help' => t('Adds a text field for editing the quantity.'),
-    'id' => 'edit_quantity',
+    'id' => 'commerce_line_item_edit_quantity',
   ];
-  $data['commerce_line_item']['edit_remove']['field'] = [
+  $data['commerce_line_item']['remove_button']['field'] = [
     'title' => t('Remove button'),
     'help' => t('Adds a button for removing the line item.'),
-    'id' => 'edit_remove',
+    'id' => 'commerce_line_item_remove_button',
   ];
 }

--- a/modules/cart/config/install/views.view.commerce_cart_form.yml
+++ b/modules/cart/config/install/views.view.commerce_cart_form.yml
@@ -193,7 +193,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: amount
-          type: price_default
+          type: commerce_price_default
           settings:
             strip_trailing_zeroes: true
             display_currency_code: false
@@ -259,11 +259,11 @@ display:
           empty_zero: false
           hide_alter_empty: true
           entity_type: commerce_line_item
-          plugin_id: edit_quantity
-        edit_remove:
-          id: edit_remove
+          plugin_id: commerce_line_item_edit_quantity
+        remove_button:
+          id: remove_button
           table: commerce_line_item
-          field: edit_remove
+          field: remove_button
           relationship: line_items
           group_type: group
           admin_label: ''
@@ -309,7 +309,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           entity_type: commerce_line_item
-          plugin_id: edit_remove
+          plugin_id: commerce_line_item_remove_button
         total_price__amount:
           id: total_price__amount
           table: commerce_line_item
@@ -359,7 +359,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: amount
-          type: price_default
+          type: commerce_price_default
           settings:
             strip_trailing_zeroes: true
             display_currency_code: false

--- a/modules/cart/config/install/views.view.commerce_carts.yml
+++ b/modules/cart/config/install/views.view.commerce_carts.yml
@@ -207,7 +207,7 @@ display:
           hide_single_bundle: true
           entity_type: commerce_order
           entity_field: type
-          plugin_id: entity_bundle
+          plugin_id: commerce_entity_bundle
         store_id:
           id: store_id
           table: commerce_order
@@ -273,7 +273,7 @@ display:
           hide_single_store: true
           entity_type: commerce_order
           entity_field: store_id
-          plugin_id: store
+          plugin_id: commerce_store
         uid:
           id: uid
           table: commerce_order
@@ -452,7 +452,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: amount
-          type: price_default
+          type: commerce_price_default
           settings:
             strip_trailing_zeroes: false
             display_currency_code: false
@@ -665,7 +665,7 @@ display:
             group_items: {  }
           entity_type: commerce_order
           entity_field: type
-          plugin_id: entity_bundle
+          plugin_id: commerce_entity_bundle
       sorts: {  }
       title: Carts
       header: {  }

--- a/modules/cart/src/Plugin/views/Field/EditQuantity.php
+++ b/modules/cart/src/Plugin/views/Field/EditQuantity.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Defines a form element for editing the line item quantity.
  *
- * @ViewsField("edit_quantity")
+ * @ViewsField("commerce_line_item_edit_quantity")
  */
 class EditQuantity extends FieldPluginBase {
 

--- a/modules/cart/src/Plugin/views/Field/RemoveButton.php
+++ b/modules/cart/src/Plugin/views/Field/RemoveButton.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\commerce_cart\Plugin\views\Field\EditRemove.
+ * Contains \Drupal\commerce_cart\Plugin\views\Field\RemoveButton.
  */
 
 namespace Drupal\commerce_cart\Plugin\views\Field;
@@ -15,11 +15,11 @@ use Drupal\views\ResultRow;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Defines a form element for editing the line item quantity.
+ * Defines a form element for removing the line item.
  *
- * @ViewsField("edit_remove")
+ * @ViewsField("commerce_line_item_remove_button")
  */
-class EditRemove extends FieldPluginBase {
+class RemoveButton extends FieldPluginBase {
 
   use UncacheableFieldHandlerTrait;
 

--- a/modules/order/commerce_order.module
+++ b/modules/order/commerce_order.module
@@ -163,6 +163,6 @@ function commerce_order_add_line_items_field($order_type) {
  * Implements hook_views_data_alter().
  */
 function commerce_order_views_data_alter(array &$data) {
-  $data['commerce_order']['store_id']['field']['id'] = 'store';
+  $data['commerce_order']['store_id']['field']['id'] = 'commerce_store';
   $data['commerce_order']['state']['filter']['id'] = 'state_machine_state';
 }

--- a/modules/order/config/install/core.entity_view_display.commerce_order.default.default.yml
+++ b/modules/order/config/install/core.entity_view_display.commerce_order.default.default.yml
@@ -21,7 +21,7 @@ content:
     third_party_settings: {  }
     label: hidden
   order_total:
-    type: price_default
+    type: commerce_price_default
     weight: 1
     settings:
       strip_trailing_zeroes: false

--- a/modules/order/config/install/views.view.commerce_orders.yml
+++ b/modules/order/config/install/views.view.commerce_orders.yml
@@ -357,7 +357,7 @@ display:
           hide_single_bundle: true
           entity_type: commerce_order
           entity_field: type
-          plugin_id: entity_bundle
+          plugin_id: commerce_entity_bundle
         store_id:
           id: store_id
           table: commerce_order
@@ -423,7 +423,7 @@ display:
           hide_single_store: true
           entity_type: commerce_order
           entity_field: store_id
-          plugin_id: store
+          plugin_id: commerce_store
         uid:
           id: uid
           table: commerce_order
@@ -666,7 +666,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: amount
-          type: price_default
+          type: commerce_price_default
           settings:
             strip_trailing_zeroes: false
             display_currency_code: false
@@ -816,7 +816,7 @@ display:
             group_items: {  }
           entity_type: commerce_order
           entity_field: type
-          plugin_id: entity_bundle
+          plugin_id: commerce_entity_bundle
         state:
           id: state
           table: commerce_order

--- a/modules/order/src/Entity/LineItem.php
+++ b/modules/order/src/Entity/LineItem.php
@@ -213,7 +213,7 @@ class LineItem extends ContentEntityBase implements LineItemInterface {
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
-    $fields['unit_price'] = BaseFieldDefinition::create('price')
+    $fields['unit_price'] = BaseFieldDefinition::create('commerce_price')
       ->setLabel(t('Unit price'))
       ->setDescription(t('The price of a single unit.'))
       ->setRequired(TRUE)
@@ -224,7 +224,7 @@ class LineItem extends ContentEntityBase implements LineItemInterface {
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
-    $fields['total_price'] = BaseFieldDefinition::create('price')
+    $fields['total_price'] = BaseFieldDefinition::create('commerce_price')
       ->setLabel(t('Total price'))
       ->setDescription(t('The total price of the line item.'))
       ->setReadOnly(TRUE)

--- a/modules/order/src/Entity/Order.php
+++ b/modules/order/src/Entity/Order.php
@@ -458,7 +458,7 @@ class Order extends ContentEntityBase implements OrderInterface {
       ->setDisplayConfigurable('view', TRUE)
       ->setSetting('workflow_callback', ['\Drupal\commerce_order\Entity\Order', 'getWorkflow']);
 
-    $fields['order_total'] = BaseFieldDefinition::create('price')
+    $fields['order_total'] = BaseFieldDefinition::create('commerce_price')
       ->setLabel(t('Total price'))
       ->setDescription(t('The total price of the order.'))
       ->setReadOnly(TRUE)

--- a/modules/order/src/Form/OrderAddForm.php
+++ b/modules/order/src/Form/OrderAddForm.php
@@ -56,13 +56,13 @@ class OrderAddForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form['type'] = [
-      '#type' => 'entity_select',
+      '#type' => 'commerce_entity_select',
       '#title' => $this->t('Order type'),
       '#target_type' => 'commerce_order_type',
       '#required' => TRUE,
     ];
     $form['store_id'] = [
-      '#type' => 'entity_select',
+      '#type' => 'commerce_entity_select',
       '#title' => $this->t('Store'),
       '#target_type' => 'commerce_store',
       '#required' => TRUE,

--- a/modules/price/config/schema/commerce_price.schema.yml
+++ b/modules/price/config/schema/commerce_price.schema.yml
@@ -18,7 +18,7 @@ commerce_price.commerce_currency.*:
       type: integer
       label: 'Fraction digits'
 
-field.formatter.settings.price_default:
+field.formatter.settings.commerce_price_default:
   type: mapping
   label: 'Default price formatter settings'
   mapping:

--- a/modules/price/src/Plugin/Field/FieldFormatter/PriceDefaultFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PriceDefaultFormatter.php
@@ -19,10 +19,10 @@ use CommerceGuys\Intl\Formatter\NumberFormatterInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Plugin implementation of the 'price_default' formatter.
+ * Plugin implementation of the 'commerce_price_default' formatter.
  *
  * @FieldFormatter(
- *   id = "price_default",
+ *   id = "commerce_price_default",
  *   label = @Translation("Default"),
  *   field_types = {
  *     "price"

--- a/modules/price/src/Plugin/Field/FieldFormatter/PricePlainFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PricePlainFormatter.php
@@ -16,10 +16,10 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Plugin implementation of the 'price_plain' formatter.
+ * Plugin implementation of the 'commerce_price_plain' formatter.
  *
  * @FieldFormatter(
- *   id = "price_plain",
+ *   id = "commerce_price_plain",
  *   label = @Translation("Plain"),
  *   field_types = {
  *     "price"

--- a/modules/price/src/Plugin/Field/FieldType/Price.php
+++ b/modules/price/src/Plugin/Field/FieldType/Price.php
@@ -12,14 +12,14 @@ use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\TypedData\DataDefinition;
 
 /**
- * Plugin implementation of the commerce price field type.
+ * Plugin implementation of the 'commerce_price' field type.
  *
  * @FieldType(
- *   id = "price",
+ *   id = "commerce_price",
  *   label = @Translation("Price"),
  *   description = @Translation("Stores a decimal amount and a three letter currency code."),
- *   default_widget = "price_default",
- *   default_formatter = "price_default",
+ *   default_widget = "commerce_price_default",
+ *   default_formatter = "commerce_price_default",
  * )
  */
 class Price extends FieldItemBase {

--- a/modules/price/src/Plugin/Field/FieldWidget/PriceDefaultWidget.php
+++ b/modules/price/src/Plugin/Field/FieldWidget/PriceDefaultWidget.php
@@ -19,10 +19,10 @@ use CommerceGuys\Intl\Formatter\NumberFormatterInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Plugin implementation of the 'price_default' widget.
+ * Plugin implementation of the 'commerce_price_default' widget.
  *
  * @FieldWidget(
- *   id = "price_default",
+ *   id = "commerce_price_default",
  *   label = @Translation("Price"),
  *   field_types = {
  *     "price"

--- a/modules/price/templates/commerce-price-plain.html.twig
+++ b/modules/price/templates/commerce-price-plain.html.twig
@@ -3,7 +3,7 @@
  * @file
  * Default theme implementation for displaying a price.
  *
- * Used by the 'price_plain' formatter.
+ * Used by the 'commerce_price_plain' formatter.
  * Available variables:
  *   - amount: The decimal amount.
  *   - currency: The currency entity.

--- a/modules/product/commerce_product.info.yml
+++ b/modules/product/commerce_product.info.yml
@@ -25,4 +25,6 @@ config_devel:
   - field.field.commerce_product.default.body
   - field.field.commerce_product.default.stores
   - field.field.commerce_product.default.variations
+  - system.action.commerce_publish_product
+  - system.action.commerce_unpublish_product
   - views.view.commerce_products

--- a/modules/product/commerce_product.module
+++ b/modules/product/commerce_product.module
@@ -64,7 +64,7 @@ function commerce_product_add_stores_field($product_type) {
     // Assign widget settings for the 'default' form mode.
     entity_get_form_display('commerce_product', $product_type->id(), 'default')
       ->setComponent('stores', [
-        'type' => 'entity_select',
+        'type' => 'commerce_entity_select',
         'weight' => -10,
       ])
       ->save();

--- a/modules/product/config/install/core.entity_form_display.commerce_product.default.default.yml
+++ b/modules/product/config/install/core.entity_form_display.commerce_product.default.default.yml
@@ -35,7 +35,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   stores:
-    type: entity_select
+    type: commerce_entity_select
     weight: 0
     settings:
       autocomplete_threshold: 7

--- a/modules/product/config/install/core.entity_form_display.commerce_product_variation.default.default.yml
+++ b/modules/product/config/install/core.entity_form_display.commerce_product_variation.default.default.yml
@@ -11,7 +11,7 @@ bundle: default
 mode: default
 content:
   price:
-    type: price_default
+    type: commerce_price_default
     weight: 0
     settings: {  }
     third_party_settings: {  }

--- a/modules/product/config/install/core.entity_view_display.commerce_product.default.default.yml
+++ b/modules/product/config/install/core.entity_view_display.commerce_product.default.default.yml
@@ -22,7 +22,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   variations:
-    type: add_to_cart
+    type: commerce_add_to_cart
     weight: 1
     label: hidden
     settings:

--- a/modules/product/config/install/system.action.commerce_publish_product.yml
+++ b/modules/product/config/install/system.action.commerce_publish_product.yml
@@ -3,8 +3,8 @@ status: true
 dependencies:
   module:
     - commerce_product
-id: publish_product_action
+id: commerce_publish_product
 label: 'Publish product'
 type: commerce_product
-plugin: publish_product_action
+plugin: commerce_publish_product
 configuration: {  }

--- a/modules/product/config/install/system.action.commerce_unpublish_product.yml
+++ b/modules/product/config/install/system.action.commerce_unpublish_product.yml
@@ -3,8 +3,8 @@ status: true
 dependencies:
   module:
     - commerce_product
-id: unpublish_product_action
+id: commerce_unpublish_product
 label: 'Unpublish product'
 type: commerce_product
-plugin: unpublish_product_action
+plugin: commerce_unpublish_product
 configuration: {  }

--- a/modules/product/config/install/views.view.commerce_products.yml
+++ b/modules/product/config/install/views.view.commerce_products.yml
@@ -254,7 +254,7 @@ display:
           hide_single_bundle: true
           entity_type: commerce_product
           entity_field: type
-          plugin_id: entity_bundle
+          plugin_id: commerce_entity_bundle
         status:
           id: status
           table: commerce_product_field_data
@@ -482,7 +482,7 @@ display:
             group_items: {  }
           entity_type: commerce_product
           entity_field: type
-          plugin_id: entity_bundle
+          plugin_id: commerce_entity_bundle
         title:
           id: title
           table: commerce_product_field_data

--- a/modules/product/config/optional/core.entity_form_display.commerce_line_item.product_variation.default.yml
+++ b/modules/product/config/optional/core.entity_form_display.commerce_line_item.product_variation.default.yml
@@ -30,7 +30,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   unit_price:
-    type: price_default
+    type: commerce_price_default
     weight: 2
     settings: {  }
     third_party_settings: {  }

--- a/modules/product/config/optional/core.entity_view_display.commerce_line_item.product_variation.default.yml
+++ b/modules/product/config/optional/core.entity_view_display.commerce_line_item.product_variation.default.yml
@@ -11,7 +11,7 @@ bundle: product_variation
 mode: default
 content:
   total_price:
-    type: price_default
+    type: commerce_price_default
     weight: 3
     settings:
       strip_trailing_zeroes: false
@@ -37,7 +37,7 @@ content:
     third_party_settings: {  }
     label: above
   unit_price:
-    type: price_default
+    type: commerce_price_default
     weight: 2
     settings:
       strip_trailing_zeroes: false

--- a/modules/product/config/schema/commerce_product.schema.yml
+++ b/modules/product/config/schema/commerce_product.schema.yml
@@ -43,7 +43,7 @@ field.field.*.*.*.third_party.commerce_product:
         type: label
         label: 'The title of the attribute for the Add to Cart form'
 
-field.formatter.settings.add_to_cart:
+field.formatter.settings.commerce_add_to_cart:
   type: mapping
   mapping:
     show_quantity:
@@ -56,10 +56,10 @@ field.formatter.settings.add_to_cart:
       type: boolean
       label: 'Whether to attempt to combine line items containing the same product variation'
 
-action.configuration.publish_product_action:
+action.configuration.commerce_publish_product:
   type: action_configuration_default
   label: 'Configuration for the Publish product action'
 
-action.configuration.unpublish_product_action:
+action.configuration.commerce_unpublish_product:
   type: action_configuration_default
   label: 'Configuration for the Unpublish product action'

--- a/modules/product/src/Entity/ProductVariation.php
+++ b/modules/product/src/Entity/ProductVariation.php
@@ -283,16 +283,16 @@ class ProductVariation extends ContentEntityBase implements ProductVariationInte
 
     // The price is not required because it's not guaranteed to be used
     // for storage (there might be a price per currency, role, country, etc).
-    $fields['price'] = BaseFieldDefinition::create('price')
+    $fields['price'] = BaseFieldDefinition::create('commerce_price')
       ->setLabel(t('Price'))
       ->setDescription(t('The variation price'))
       ->setDisplayOptions('view', [
         'label' => 'above',
-        'type' => 'price_default',
+        'type' => 'commerce_price_default',
         'weight' => 0,
       ])
       ->setDisplayOptions('form', [
-        'type' => 'price_default',
+        'type' => 'commerce_price_default',
         'weight' => 0,
       ])
       ->setDisplayConfigurable('form', TRUE)

--- a/modules/product/src/Plugin/Action/PublishProduct.php
+++ b/modules/product/src/Plugin/Action/PublishProduct.php
@@ -14,7 +14,7 @@ use Drupal\Core\Session\AccountInterface;
  * Publishes a product.
  *
  * @Action(
- *   id = "publish_product_action",
+ *   id = "commerce_publish_product",
  *   label = @Translation("Publish selected product"),
  *   type = "commerce_product"
  * )

--- a/modules/product/src/Plugin/Action/UnpublishProduct.php
+++ b/modules/product/src/Plugin/Action/UnpublishProduct.php
@@ -14,7 +14,7 @@ use Drupal\Core\Session\AccountInterface;
  * Unpublishes a product.
  *
  * @Action(
- *   id = "unpublish_product_action",
+ *   id = "commerce_unpublish_product",
  *   label = @Translation("Unpublish selected product"),
  *   type = "commerce_product"
  * )

--- a/modules/product/src/Plugin/Field/FieldFormatter/AddToCartFormatter.php
+++ b/modules/product/src/Plugin/Field/FieldFormatter/AddToCartFormatter.php
@@ -17,10 +17,10 @@ use Drupal\Core\Render\Element;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Plugin implementation of the 'add_to_cart' formatter.
+ * Plugin implementation of the 'commerce_add_to_cart' formatter.
  *
  * @FieldFormatter(
- *   id = "add_to_cart",
+ *   id = "commerce_add_to_cart",
  *   label = @Translation("Add to cart form"),
  *   field_types = {
  *     "entity_reference",

--- a/modules/store/config/install/views.view.commerce_stores.yml
+++ b/modules/store/config/install/views.view.commerce_stores.yml
@@ -238,7 +238,7 @@ display:
           hide_single_bundle: true
           entity_type: commerce_store
           entity_field: type
-          plugin_id: entity_bundle
+          plugin_id: commerce_entity_bundle
         operations:
           id: operations
           table: commerce_store
@@ -332,7 +332,7 @@ display:
             group_items: {  }
           entity_type: commerce_store
           entity_field: type
-          plugin_id: entity_bundle
+          plugin_id: commerce_entity_bundle
       sorts: {  }
       title: Stores
       header: {  }

--- a/modules/store/config/schema/commerce_store.schema.yml
+++ b/modules/store/config/schema/commerce_store.schema.yml
@@ -22,7 +22,7 @@ commerce_store.settings:
       type: string
       label: 'Default store UUID'
 
-views.field.store:
+views.field.commerce_store:
   type: views.field.field
   mapping:
     hide_single_store:

--- a/modules/store/src/Plugin/views/field/Store.php
+++ b/modules/store/src/Plugin/views/field/Store.php
@@ -20,7 +20,7 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * @ingroup views_field_handlers
  *
- * @ViewsField("store")
+ * @ViewsField("commerce_store")
  */
 class Store extends Field {
 

--- a/src/Element/EntitySelect.php
+++ b/src/Element/EntitySelect.php
@@ -30,14 +30,14 @@ use Drupal\Core\Render\Element\FormElement;
  * Example usage:
  * @code
  * $form['entities'] = [
- *   '#type' => 'entity_select',
+ *   '#type' => 'commerce_entity_select',
  *   '#title' => t('Stores'),
  *   '#target_type' => 'commerce_store',
  *   '#multiple' => TRUE,
  * ];
  * @end
  *
- * @FormElement("entity_select")
+ * @FormElement("commerce_entity_select")
  */
 class EntitySelect extends FormElement {
 

--- a/src/Plugin/Field/FieldWidget/EntitySelectWidget.php
+++ b/src/Plugin/Field/FieldWidget/EntitySelectWidget.php
@@ -12,10 +12,10 @@ use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Plugin implementation of the 'entity_select' widget.
+ * Plugin implementation of the 'commerce_entity_select' widget.
  *
  * @FieldWidget(
- *   id = "entity_select",
+ *   id = "commerce_entity_select",
  *   label = @Translation("Entity select"),
  *   field_types = {
  *     "entity_reference"
@@ -100,7 +100,7 @@ class EntitySelectWidget extends WidgetBase {
     }
 
     $element += [
-      '#type' => 'entity_select',
+      '#type' => 'commerce_entity_select',
       '#target_type' => $this->getFieldSetting('target_type'),
       '#multiple' => $multiple,
       '#default_value' => $default_value,

--- a/src/Plugin/views/field/EntityBundle.php
+++ b/src/Plugin/views/field/EntityBundle.php
@@ -20,7 +20,7 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * @ingroup views_field_handlers
  *
- * @ViewsField("entity_bundle")
+ * @ViewsField("commerce_entity_bundle")
  */
 class EntityBundle extends Field {
 

--- a/src/Plugin/views/filter/EntityBundle.php
+++ b/src/Plugin/views/filter/EntityBundle.php
@@ -18,7 +18,7 @@ use Drupal\views\Plugin\views\filter\Bundle;
  *
  * @ingroup views_filter_handlers
  *
- * @ViewsFilter("entity_bundle")
+ * @ViewsFilter("commerce_entity_bundle")
  */
 class EntityBundle extends Bundle {
 

--- a/src/Tests/EntitySelectWidgetTest.php
+++ b/src/Tests/EntitySelectWidgetTest.php
@@ -76,7 +76,7 @@ class EntitySelectWidgetTest extends WebTestBase {
     $this->referenceField = FieldStorageConfig::loadByName('commerce_product', 'stores');
     $display = EntityFormDisplay::load('commerce_product.default.default');
     $display->setComponent('stores', [
-      'type' => 'entity_select',
+      'type' => 'commerce_entity_select',
       'settings' => [
         'autocomplete_threshold' => 2,
       ],


### PR DESCRIPTION
Some notes:
- Decided to do commerce_entity_bundle instead of commerce_bundle because core mostly adds entity_ to entity specific handlers
- Removed the _action suffix from the product actions, core does it everywhere for actions, but no other plugin type does that.
- I'm unhappy about commerce_edit_quantity and commerce_edit_remove, but no better ideas for now (edit_quantity and edit_remove are names taken from 1.x)
