### PR TITLE
2659096 improve interface tests

### DIFF
--- a/modules/product/src/Entity/Product.php
+++ b/modules/product/src/Entity/Product.php
@@ -169,8 +169,7 @@ class Product extends ContentEntityBase implements ProductInterface {
    * {@inheritdoc}
    */
   public function getOwnerId() {
-    $this->get('uid')->target_id;
-    return $this;
+    return $this->get('uid')->target_id;
   }
 
   /**

--- a/modules/product/tests/src/Kernel/Entity/ProductTest.php
+++ b/modules/product/tests/src/Kernel/Entity/ProductTest.php
@@ -2,9 +2,14 @@
 
 namespace Drupal\Tests\commerce_product\Kernel\Entity;
 
-use Drupal\commerce_product\Entity\ProductVariation;
 use Drupal\commerce_product\Entity\Product;
+use Drupal\commerce_product\Entity\ProductType;
+use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\commerce_product\Entity\ProductVariationType;
+use Drupal\commerce_store\Entity\Store;
+use Drupal\commerce_store\Entity\StoreType;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
 
 /**
  * Tests the Product entity.
@@ -21,10 +26,31 @@ class ProductTest extends KernelTestBase {
    * @var array
    */
   public static $modules = [
-    'system', 'field', 'options', 'user', 'path', 'text', 'filter', 'entity',
-    'entity', 'entity_test', 'address', 'views', 'inline_entity_form',
-    'commerce', 'commerce_price', 'commerce_store', 'commerce_product',
+    'profile',
+    'state_machine',
+    'commerce_order',
+    'system',
+    'field',
+    'options',
+    'user',
+    'path',
+    'text',
+    'filter',
+    'entity',
+    'entity_test',
+    'address',
+    'views',
+    'inline_entity_form',
+    'commerce',
+    'commerce_price',
+    'commerce_store',
+    'commerce_product',
   ];
+
+  protected $variation;
+  protected $variationType;
+  protected $productType;
+  protected $user;
 
   /**
    * {@inheritdoc}
@@ -32,14 +58,45 @@ class ProductTest extends KernelTestBase {
   protected function setUp() {
     parent::setUp();
 
+    $this->installEntitySchema('user');
     $this->installEntitySchema('commerce_product_variation');
     $this->installEntitySchema('commerce_product_variation_type');
+    $this->installEntitySchema('commerce_store');
     $this->installEntitySchema('commerce_product');
     $this->installEntitySchema('commerce_product_type');
     $this->installConfig(['commerce_product']);
+
+    // Create a variation.
+    $this->variation = ProductVariation::create([
+      'sku' => 'AZAE1252',
+      'status' => TRUE,
+      'price' => 9.99,
+      'variation_id' => 12,
+      'type' => 'default',
+    ]);
+    $this->variation->save();
+
+    // Create a product type.
+    $this->productType = ProductType::create([
+      'label' => 'default',
+      'id' => 1,
+      'variationType' => 'default',
+      'description' => 'test',
+    ]);
+    $this->productType->save();
+
+    // Create a user.
+    $this->user = User::create([
+      'name' => 'test',
+      'uid' => 1,
+      'status' => TRUE,
+    ]);
+    $this->user->save();
   }
 
   /**
+   * Tests default variation.
+   *
    * @covers ::getVariations
    * @covers ::setVariations
    * @covers ::hasVariations
@@ -89,6 +146,120 @@ class ProductTest extends KernelTestBase {
 
     $this->assertEquals($product->getDefaultVariation(), $variation2);
     $this->assertNotEquals($product->getDefaultVariation(), $variation1);
+  }
+
+  /**
+   * Tests getters and setters for the Product interface.
+   *
+   * @covers ::getStores
+   * @covers ::setStores
+   * @covers ::getTitle
+   * @covers ::setTitle
+   * @covers ::isPublished
+   * @covers ::setPublished
+   * @covers ::getCreatedTime
+   * @covers ::setCreatedTime
+   * @covers ::getOwner
+   * @covers ::getOwnerId
+   * @covers ::setOwner
+   * @covers ::setOwnerId
+   */
+  public function testProduct() {
+    // Create a store type.
+    $storeType = StoreType::create([
+      'id' => 'StoreType',
+      'label' => 'Store Type',
+    ]);
+    $storeType->save();
+
+    // Create a store.
+    $store = Store::create([
+      'type' => $storeType->id(),
+      'name' => 'My fancy store',
+    ]);
+    $store->save();
+
+    // Add the reference field to the Product type.
+    commerce_product_add_stores_field($this->productType);
+    commerce_product_add_variations_field($this->productType);
+
+    // Create a product.
+    $product = Product::create([
+      'title' => 'Test Product',
+      'variations' => [$this->variation],
+      'body' => 'Longer text then the title',
+      'status' => TRUE,
+      'type' => $this->productType->id(),
+      'created' => 1454515675,
+      'stores' => [$store],
+      'uid' => $this->user->id(),
+    ]);
+    $product->save();
+
+    // Product: Check if the store has been correctly set.
+    $productStores = $product->getStores();
+    $this->assertEquals($productStores[0]->id(), $store->id());
+
+    // Create a new store.
+    $newStore = Store::create([
+      'type' => $storeType->id(),
+      'name' => 'My fancy store',
+    ]);
+    $newStore->save();
+    $product->setStores([$newStore]);
+    $product->save();
+
+    // Product: Check if the new store has been correctly set.
+    $productStores = $product->getStores();
+    $this->assertEquals($productStores[0]->id(), $newStore->id());
+
+    // Product: Test title get and set.
+    $this->assertEquals('Test Product', $product->getTitle());
+    $product->setTitle('Test new title');
+    $product->save();
+    $this->assertEquals('Test new title', $product->getTitle());
+
+    // Product: Published status get and set.
+    $this->assertTrue($product->isPublished());
+    $product->setPublished(FALSE);
+    $product->save();
+    $this->assertFalse($product->isPublished());
+
+    // Product: Creation time get and set.
+    $this->assertEquals(1454515675, $product->getCreatedTime());
+    $timestamp_test = time();
+    $product->setCreatedTime($timestamp_test);
+    $product->save();
+    $this->assertEquals($timestamp_test, $product->getCreatedTime());
+
+    // Product: test getOwnerId and GetOWnder.
+    $currentOwner = $product->getOwner();
+    $this->assertEquals($currentOwner->id(), $this->user->id());
+    $this->assertEquals($product->getOwnerId(), $this->user->id());
+
+    // Set a new user.
+    $secondUser = User::create([
+      'name' => 'seconduser',
+      'uid' => 2,
+      'status' => TRUE,
+    ]);
+    $secondUser->save();
+
+    // Product: test setOwner.
+    $product->setOwner($secondUser);
+    $product->save();
+
+    // Product: test getOwnerId and GetOWnder with the new owner.
+    $this->assertEquals($product->getOwner()->id(), $secondUser->id());
+    $this->assertEquals($product->getOwnerId(), $secondUser->id());
+
+    // Product: set Owner back to 1 testing setOwnerId.
+    $product->setOwnerId($this->user->id());
+    $product->save();
+
+    // Product: test getOwnerId and GetOWnder with the original owner.
+    $this->assertEquals($product->getOwner()->id(), $this->user->id());
+    $this->assertEquals($product->getOwnerId(), $this->user->id());
   }
 
 }

--- a/modules/product/tests/src/Kernel/Entity/ProductVariationTest.php
+++ b/modules/product/tests/src/Kernel/Entity/ProductVariationTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\Tests\commerce_product\Kernel\Entity\ProductVariationTest.
+ */
+
+namespace Drupal\Tests\commerce_product\Kernel\Entity;
+
+use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the Product Variation entity.
+ *
+ * @coversDefaultClass \Drupal\commerce_product\Entity\ProductVariation
+ *
+ * @group commerce
+ */
+class ProductVariationTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'profile',
+    'state_machine',
+    'commerce_order',
+    'system',
+    'field',
+    'options',
+    'user',
+    'path',
+    'text',
+    'filter',
+    'entity',
+    'entity_test',
+    'address',
+    'views',
+    'inline_entity_form',
+    'commerce',
+    'commerce_price',
+    'commerce_store',
+    'commerce_product',
+  ];
+
+  /**
+   * Tests getters and setters for the product variation interface.
+   *
+   * @covers ::getPrice
+   * @covers ::getSku
+   * @covers ::setSku
+   */
+  public function testProductVariation() {
+    // Create a variation.
+    $variation = ProductVariation::create([
+      'type' => 'default',
+      'sku' => 'AZAE1252',
+      'title' => $this->randomString(),
+      'status' => 1,
+      'price' => [
+        'amount' => 9.99,
+        'currency_code' => 'USD',
+      ],
+    ]);
+    $variation->save();
+
+    // ProductVariation: Test price get and set.
+    $this->assertEquals(9.99, $variation->getPrice()->getDecimalAmount());
+    $variation->set('price', [
+      'amount' => 13.37,
+      'currency_code' => 'USD',
+    ]);
+    $variation->save();
+    $this->assertEquals(13.37, $variation->getPrice()->getDecimalAmount());
+
+    // ProductVariation: Test sku get and set.
+    $this->assertEquals('AZAE1252', $variation->getSku());
+    $variation->setSku('ABAA9898');
+    $variation->save();
+    $this->assertEquals('ABAA9898', $variation->getSku());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('commerce_product_variation');
+    $this->installEntitySchema('commerce_product_variation_type');
+    $this->installEntitySchema('commerce_store');
+    $this->installEntitySchema('commerce_product');
+    $this->installEntitySchema('commerce_product_type');
+    $this->installConfig(['commerce_product']);
+    $this->container->get('commerce_price.currency_importer')->import('USD');
+  }
+
+}

--- a/modules/store/tests/src/Kernel/Entity/StoreTest.php
+++ b/modules/store/tests/src/Kernel/Entity/StoreTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\Tests\commerce_store\Kernel\Entity\StoreTest.
+ */
+
+namespace Drupal\Tests\commerce_store\Kernel\Entity;
+
+use Drupal\commerce_price\Entity\Currency;
+use Drupal\commerce_store\Entity\Store;
+use Drupal\user\Entity\User;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the Store entity.
+ *
+ * @coversDefaultClass \Drupal\commerce_store\Entity\Store
+ *
+ * @group commerce
+ */
+class StoreTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'system',
+    'field',
+    'options',
+    'user',
+    'views',
+    'address',
+    'profile',
+    'state_machine',
+    'commerce',
+    'commerce_store',
+    'commerce_price',
+    'text',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Setup schema's.
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('profile');
+    $this->installEntitySchema('commerce_store');
+  }
+
+  /**
+   * Tests commerce Store Interface.
+   *
+   * @covers ::id
+   * @covers ::getName
+   * @covers ::getOwner
+   * @covers ::getOwnerId
+   * @covers ::setOwner
+   * @covers ::setOwnerId
+   * @covers ::getEmail
+   * @covers ::setEmail
+   * @covers ::getDefaultCurrency
+   * @covers ::setDefaultCurrency
+   * @covers ::getDefaultCurrencyCode
+   * @covers ::setDefaultCurrencyCode
+   * @covers ::getAddress
+   */
+  public function testStore() {
+    // Create two currencies.
+    // Euro.
+    $euro_currency = Currency::create([
+      'currencyCode' => 'EUR',
+      'name' => 'Euro',
+      'numericCode' => 123,
+      'symbol' => '€',
+      'fractionDigits' => 2,
+    ]);
+    $euro_currency->save();
+    // Dollar.
+    $dollar_currency = Currency::create([
+      'currencyCode' => 'USD',
+      'name' => 'Dollar',
+      'numericCode' => 139,
+      'symbol' => '$',
+      'fractionDigits' => 2,
+    ]);
+    $dollar_currency->save();
+
+    // Create a user.
+    $user = User::create([
+      'name' => 'test',
+      'uid' => 1,
+      'status' => TRUE,
+    ]);
+    $user->save();
+
+    $store_address = [
+      'country' => 'FR',
+      'postal_code' => '75003',
+      'locality' => 'Paris',
+      'address_line1' => 'A different french street',
+    ];
+
+    // Create a store.
+    $store = Store::create([
+      'type' => 'default',
+      'name' => 'My fancy store',
+      'store_id' => 15,
+      'uid' => $user->id(),
+      'mail' => 'info@store.mail',
+      'default_currency' => $euro_currency,
+      'address' => $store_address,
+      'billing_countries' => ['FR'],
+    ]);
+    $store->save();
+
+    // Check if the id matches.
+    $this->assertEquals($store->id(), 15);
+
+    // Store: test getName() and setName().
+    $this->assertEquals($store->getName(), 'My fancy store');
+    $store->setName('My normal store');
+    $store->save();
+    $this->assertEquals($store->getName(), 'My normal store');
+
+    // Store: test getOwner() and getOwnerId().
+    $this->assertEquals($store->getOwner()->id(), $user->id());
+    $this->assertEquals($store->getOwnerId(), $user->id());
+
+    // Create a new user.
+    $new_user = User::create([
+      'name' => 'newuser',
+      'uid' => 2,
+      'status' => TRUE,
+    ]);
+    $new_user->save();
+
+    // Store: test setOwner() and retest getOwner() and getOwnerId().
+    $store->setOwner($new_user);
+    $store->save();
+    $this->assertEquals($store->getOwner()->id(), $new_user->id());
+    $this->assertEquals($store->getOwnerId(), $new_user->id());
+
+    // Store: test setOwnerId() and retest getOwner() and getOwnerId().
+    $store->setOwnerID($user->id());
+    $store->save();
+    $this->assertEquals($store->getOwner()->id(), $user->id());
+    $this->assertEquals($store->getOwnerId(), $user->id());
+
+    // Store: test getEmail() and getEmail().
+    $this->assertEquals($store->getEmail(), 'info@store.mail');
+    $store->setEmail('sales@store.mail');
+    $store->save();
+    $this->assertEquals($store->getEmail(), 'sales@store.mail');
+
+    // Store: test getDefaultCurrency() and setDefaultCurrency().
+    $this->assertEquals($store->getDefaultCurrency()->getCurrencyCode(), $euro_currency->getCurrencyCode());
+    $store->setDefaultCurrency($dollar_currency);
+    $store->save();
+    $this->assertEquals($store->getDefaultCurrency()->getCurrencyCode(), $dollar_currency->getCurrencyCode());
+
+    // Store: test getDefaultCurrencyCode() and setDefaultCurrencyCode().
+    $this->assertEquals($store->getDefaultCurrencyCode(), $dollar_currency->getCurrencyCode());
+    $store->setDefaultCurrencyCode($euro_currency->getCurrencyCode());
+    $store->save();
+    $this->assertEquals($store->getDefaultCurrencyCode(), $euro_currency->getCurrencyCode());
+
+    // TODO: Store: test getAddress().
+  }
+}


### PR DESCRIPTION
Hi,

The full implementation is not complete yet, as I'm having some issues adding an address to an entity.

The only methods yet to be implemented are:

```
  public function getAddress();
  public function setAddress(AddressInterface $address);
  public function getBillingCountries();
  public function setBillingCountries(array $countries);
```

All other tests for Product, ProductVariation and Store are there.

I'm already opening this as we could already take advantage of the tests that are there.

I also included a small fix in product::getOwnerId.

Regards,
