### PR TITLE
Issue #2664676: Add test cases for empty store

### DIFF
--- a/modules/order/src/Tests/OrderEmptyStoreTest.php
+++ b/modules/order/src/Tests/OrderEmptyStoreTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\commerce_order\Tests;
+
+use Drupal\commerce\Tests\CommerceTestBase;
+use Drupal\Core\Url;
+
+/**
+ * Empty Store order page test.
+ *
+ * @group commerce
+ */
+class OrderEmptyStoreTest extends CommerceTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'commerce_order',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAdministratorPermissions() {
+    return array_merge([
+      'administer orders',
+      'administer order types',
+    ], parent::getAdministratorPermissions());
+  }
+
+  /**
+   * Tests order create page.
+   */
+  function testCreateOrderPage() {
+    $this->drupalGet('admin/commerce/orders');
+    $this->clickLink('Create a new order');
+
+    // Check the link is present.
+    $this->assertLink(t('Add a new store.'));
+    $this->assertLinkByHref(Url::fromRoute('entity.commerce_store.add_page')->toString());
+  }
+}

--- a/modules/product/src/Tests/ProductEmptyStoreTest.php
+++ b/modules/product/src/Tests/ProductEmptyStoreTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\commerce_product\Tests;
+
+use Drupal\commerce\Tests\CommerceTestBase;
+use Drupal\Core\Url;
+
+/**
+ * Empty Store product page test.
+ *
+ * @group commerce
+ */
+class ProductEmptyStoreTest extends CommerceTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'commerce_store',
+    'commerce_product',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAdministratorPermissions() {
+    return array_merge([
+      'administer products',
+      'administer product types',
+    ], parent::getAdministratorPermissions());
+  }
+
+  /**
+   * Tests creating a product.
+   */
+  function testCreateProduct() {
+    $this->drupalGet('admin/commerce/products');
+    $this->clickLink('Add product');
+
+    // Check the link is present.
+    $this->assertLink(t('Add a new store.'));
+    $this->assertLinkByHref(Url::fromRoute('entity.commerce_store.add_page')->toString());
+  }
+}


### PR DESCRIPTION
Added new test classes. OrderEmptyStoreTest, ProductEmptyStoreTest.
based on comments of - https://github.com/drupalcommerce/commerce/pull/345
