### PR TITLE
implement basic price calculation logic

### DIFF
--- a/modules/cart/commerce_cart.info.yml
+++ b/modules/cart/commerce_cart.info.yml
@@ -6,6 +6,7 @@ core: 8.x
 dependencies:
   - commerce
   - commerce_order
+  - commerce_price
   - commerce_product
   - views
 config_devel:

--- a/modules/cart/commerce_cart.services.yml
+++ b/modules/cart/commerce_cart.services.yml
@@ -13,7 +13,7 @@ services:
 
   commerce_cart.cart_manager:
     class: Drupal\commerce_cart\CartManager
-    arguments: ['@entity_type.manager', '@commerce_cart.line_item_matcher', '@event_dispatcher']
+    arguments: ['@entity_type.manager', '@commerce_cart.line_item_matcher', '@event_dispatcher', '@commerce_price.chain_price_resolver']
 
   commerce_cart.line_item_matcher:
       class: Drupal\commerce_cart\LineItemMatcher

--- a/modules/price/commerce_price.services.yml
+++ b/modules/price/commerce_price.services.yml
@@ -10,3 +10,13 @@ services:
   commerce_price.number_formatter_factory:
     class: Drupal\commerce_price\NumberFormatterFactory
     arguments: ['@commerce.locale_context', '@commerce_price.number_format_repository']
+
+  commerce_price.chain_price_resolver:
+    class: Drupal\commerce_price\Resolver\ChainPriceResolver
+    tags:
+      - { name: service_collector, call: addResolver, tag: commerce_price.price_resolver }
+
+  commerce_price.default_price_resolver:
+    class: Drupal\commerce_price\Resolver\DefaultPriceResolver
+    tags:
+      - { name: commerce_price.base_price_resolver, priority: -100 }

--- a/modules/price/src/Resolver/ChainPriceResolver.php
+++ b/modules/price/src/Resolver/ChainPriceResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\commerce_price\Resolver;
+
+use Drupal\commerce\PurchasableEntityInterface;
+
+/**
+ * Default implementation of the chain base price resolver.
+ */
+class ChainPriceResolver implements ChainPriceResolverInterface {
+
+  /**
+   * The resolvers.
+   *
+   * @var \Drupal\commerce_price\Resolver\PriceResolverInterface[]
+   */
+  protected $resolvers = [];
+
+  /**
+   * Constructs a new ChainBasePriceResolver object.
+   *
+   * @param \Drupal\commerce_price\Resolver\PriceResolverInterface[] $resolvers
+   *   The resolvers.
+   */
+  public function __construct(array $resolvers = []) {
+    $this->resolvers = $resolvers;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addResolver(PriceResolverInterface $resolver) {
+    $this->resolvers[] = $resolver;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResolvers() {
+    return $this->resolvers;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolve(PurchasableEntityInterface $entity, $quantity = 1) {
+    foreach ($this->resolvers as $resolver) {
+      $result = $resolver->resolve($entity, $quantity);
+      if ($result) {
+        return $result;
+      }
+    }
+  }
+
+}

--- a/modules/price/src/Resolver/ChainPriceResolverInterface.php
+++ b/modules/price/src/Resolver/ChainPriceResolverInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\commerce_price\Resolver;
+
+/**
+ * Runs the added resolvers one by one until one of them returns the price.
+ *
+ * Each resolver in the chain can be another chain, which is why this interface
+ * extends the base price resolver one.
+ */
+interface ChainPriceResolverInterface extends PriceResolverInterface {
+
+  /**
+   * Adds a resolver.
+   *
+   * @param \Drupal\commerce_price\Resolver\PriceResolverInterface $resolver
+   *   The resolver.
+   */
+  public function addResolver(PriceResolverInterface $resolver);
+
+  /**
+   * Gets all added resolvers.
+   *
+   * @return \Drupal\commerce_price\Resolver\PriceResolverInterface[]
+   *   The resolvers.
+   */
+  public function getResolvers();
+
+}

--- a/modules/price/src/Resolver/DefaultPriceResolver.php
+++ b/modules/price/src/Resolver/DefaultPriceResolver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\commerce_price\Resolver;
+
+use Drupal\commerce\PurchasableEntityInterface;
+
+/**
+ * Returns the price based on the purchasable entity's price field.
+ */
+class DefaultPriceResolver implements PriceResolverInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolve(PurchasableEntityInterface $entity, $quantity = 1) {
+    return $entity->getPrice();
+  }
+
+}

--- a/modules/price/src/Resolver/PriceResolverInterface.php
+++ b/modules/price/src/Resolver/PriceResolverInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\commerce_price\Resolver;
+
+use Drupal\commerce\PurchasableEntityInterface;
+
+/**
+ * Defines the interface for base price resolvers.
+ */
+interface PriceResolverInterface {
+
+  /**
+   * Resolves the base price of a given purchasable entity.
+   *
+   * @param \Drupal\commerce\PurchasableEntityInterface $entity
+   *   The purchasable entity.
+   * @param int $quantity
+   *   The quantity.
+   *
+   * @return \Drupal\commerce_price\Price|null
+   *   A price value object, if resolved. Otherwise NULL, indicating that the
+   *   next resolver in the chain should be called.
+   */
+  public function resolve(PurchasableEntityInterface $entity, $quantity = 1);
+
+}

--- a/src/PurchasableEntityInterface.php
+++ b/src/PurchasableEntityInterface.php
@@ -43,4 +43,12 @@ interface PurchasableEntityInterface extends ContentEntityInterface {
    */
   public function getLineItemTitle();
 
+  /**
+   * Gets the purchasable entity's price.
+   *
+   * @return \Drupal\commerce_price\Price
+   *   The price.
+   */
+  public function getPrice();
+
 }


### PR DESCRIPTION
Here's my first draft for the price calculation logic. Here are a few remarks:
- I've chosen the name BasePriceResolver, like proposed by @bojanz last week.
- To be consistent with other resolvers, I've stuck to the pattern of basic and chainable resolvers, which also extend the basic interface and thererfore may be nested
- @bojanz also mentioned, it should basically have the same signature as the Availability API, which basically has a similar structure as the resolvers, but are flat and may not be nested. In contrary, the AvailabilityCheckerInterface also defines an applies() function. My default implementation of the BasePriceResolverInterface does have an function named applies(), howerver I restrained from putting it into the interface. Because as soon you make it chainable, every chained resolver also has to implement this function and further ask all children. At the time of actually resolving the price, you'd call the function twice therefore. However, these are implementation details, that can be easily changed/extended...

As the default implementation is meant for pulling the price field from ProductVariation entites, and the ProductVariation entity possesses a base field called "price", I'm convinced that there's not a more sophisticated approach necessary than checking for:

$entity->hasField('price') && !$entity->get('price')->isEmpty()

Because every other use case, like having different purchasable entities, more price fields, etc would  need a custom price resolver anyway...
