### PR TITLE
Issue #2747897 Library commerce_cart/cart_block depends on jQuery

### DIFF
--- a/modules/cart/commerce_cart.libraries.yml
+++ b/modules/cart/commerce_cart.libraries.yml
@@ -7,3 +7,6 @@ cart_block:
       css/commerce_cart.theme.css: {}
   js:
     js/commerce_cart.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal


### PR DESCRIPTION
https://www.drupal.org/node/2747897#comment-11317631

Commerce cart module miss dependencies with jquery.
