### PR TITLE
Fix PaymentGateway/Payment field handling

### DIFF
--- a/modules/payment/commerce_payment.info.yml
+++ b/modules/payment/commerce_payment.info.yml
@@ -1,0 +1,7 @@
+name: Commerce Payment
+type: module
+description: 'Provides payment functionality.'
+package: Commerce
+core: 8.x
+dependencies:
+  - commerce

--- a/modules/payment/commerce_payment.install
+++ b/modules/payment/commerce_payment.install
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Contains install and update functions for Payment.
+ */
+
+/**
+ * Implements hook_modules_installed().
+ */
+function commerce_payment_modules_installed($modules) {
+  $entity_bundle_listener = \Drupal::service('entity_bundle.listener');
+  $payment_method_type_manager = \Drupal::service('plugin.manager.commerce_payment_method_type');
+  $definitions = $payment_method_type_manager->getDefinitions();
+  $definitions = array_filter($definitions, function ($definition) use ($modules) {
+    return in_array($definition['provider'], $modules);
+  });
+  foreach ($definitions as $definition) {
+    $entity_bundle_listener->onBundleCreate($definition['id'], 'commerce_payment_method');
+  }
+}
+
+/**
+ * Implements hook_module_preuninstall().
+ */
+function commerce_payment_module_preuninstall($module) {
+  $entity_bundle_listener = \Drupal::service('entity_bundle.listener');
+  $payment_method_type_manager = \Drupal::service('plugin.manager.commerce_payment_method_type');
+  $definitions = $payment_method_type_manager->getDefinitions();
+  $definitions = array_filter($definitions, function ($definition) use ($module) {
+    return $definition['provider'] == $module;
+  });
+  foreach ($definitions as $definition) {
+    $entity_bundle_listener->onBundleDelete($definition['id'], 'commerce_payment_method');
+  }
+}

--- a/modules/payment/commerce_payment.links.action.yml
+++ b/modules/payment/commerce_payment.links.action.yml
@@ -1,0 +1,5 @@
+entity.commerce_payment_gateway.add_form:
+  route_name: entity.commerce_payment_gateway.add_form
+  title: 'Add payment gateway'
+  appears_on:
+    - entity.commerce_payment_gateway.collection

--- a/modules/payment/commerce_payment.links.menu.yml
+++ b/modules/payment/commerce_payment.links.menu.yml
@@ -1,0 +1,5 @@
+entity.commerce_payment_gateway.collection:
+  title: 'Payment gateways'
+  route_name: 'entity.commerce_payment_gateway.collection'
+  parent: 'commerce.configuration'
+  description: 'Manage your payment gateways.'

--- a/modules/payment/commerce_payment.links.task.yml
+++ b/modules/payment/commerce_payment.links.task.yml
@@ -1,0 +1,4 @@
+entity.commerce_payment_gateway.edit_form:
+  route_name: entity.commerce_payment_gateway.edit_form
+  base_route: entity.commerce_payment_gateway.edit_form
+  title: Edit

--- a/modules/payment/commerce_payment.module
+++ b/modules/payment/commerce_payment.module
@@ -99,9 +99,23 @@ function commerce_payment_entity_bundle_create($entity_type_id, $bundle) {
  */
 function commerce_payment_entity_bundle_delete($entity_type_id, $bundle) {
   if (in_array($entity_type_id, ['commerce_payment', 'commerce_payment_method'])) {
+    $delete_storage = TRUE;
+    if ($entity_type_id == 'commerce_payment') {
+      $storage = \Drupal::entityTypeManager()->getStorage('commerce_payment_gateway');
+      // Check if other payment gateways are using the same plugin
+      $usage_count = \Drupal::entityQuery('commerce_payment_gateway')
+        ->condition('plugin', $storage->load($bundle)->getPluginId())
+        ->condition('id', $bundle, '<>')
+        ->count()
+        ->execute();
+      // Avoid deleting field storage definitions
+      if ($usage_count) {
+        $delete_storage = FALSE;
+      }
+    }
     $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type_id);
     $definitions = commerce_payment_entity_bundle_field_info($entity_type, $bundle);
-    commerce_payment_delete_field_definitions($definitions);
+    commerce_payment_delete_field_definitions($definitions, $delete_storage);
   }
 }
 
@@ -125,12 +139,16 @@ function commerce_payment_create_field_definitions(array $definitions) {
  *
  * @param array $definitions
  *   The field definitions.
+ * @param bool $delete_storage
+ *   If set TRUE, field storage definition will be deleted also
  */
-function commerce_payment_delete_field_definitions(array $definitions) {
+function commerce_payment_delete_field_definitions(array $definitions, $delete_storage=FALSE) {
   $field_storage_definition_listener = \Drupal::service('field_storage_definition.listener');
   $field_definition_listener = \Drupal::service('field_definition.listener');
   foreach ($definitions as $definition) {
-    $field_storage_definition_listener->onFieldStorageDefinitionDelete($definition);
     $field_definition_listener->onFieldDefinitionDelete($definition);
+    if ($delete_storage) {
+      $field_storage_definition_listener->onFieldStorageDefinitionDelete($definition);
+    }
   }
 }

--- a/modules/payment/commerce_payment.module
+++ b/modules/payment/commerce_payment.module
@@ -142,7 +142,7 @@ function commerce_payment_create_field_definitions(array $definitions) {
  * @param bool $delete_storage
  *   If set TRUE, field storage definition will be deleted also
  */
-function commerce_payment_delete_field_definitions(array $definitions, $delete_storage=FALSE) {
+function commerce_payment_delete_field_definitions(array $definitions, $delete_storage = FALSE) {
   $field_storage_definition_listener = \Drupal::service('field_storage_definition.listener');
   $field_definition_listener = \Drupal::service('field_definition.listener');
   foreach ($definitions as $definition) {

--- a/modules/payment/commerce_payment.module
+++ b/modules/payment/commerce_payment.module
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * @file
+ * Provides payment functionality.
+ */
+
+use Drupal\Core\Entity\EntityTypeInterface;
+
+/**
+ * Implements hook_entity_bundle_info().
+ *
+ * Use payment method type plugins as commerce_payment_method bundles.
+ */
+function commerce_payment_entity_bundle_info() {
+  $bundles = [];
+  $payment_method_type_manager = \Drupal::service('plugin.manager.commerce_payment_method_type');
+  foreach ($payment_method_type_manager->getDefinitions() as $plugin_id => $definition) {
+    $bundles['commerce_payment_method'][$plugin_id]['label'] = $definition['label'];
+  }
+
+  return $bundles;
+}
+
+/**
+ * Implements hook_entity_field_storage_info().
+ */
+function commerce_payment_entity_field_storage_info(EntityTypeInterface $entity_type) {
+  $definitions = [];
+  if ($entity_type->id() == 'commerce_payment_method') {
+    $payment_method_type_manager = \Drupal::service('plugin.manager.commerce_payment_method_type');
+    foreach (array_keys($payment_method_type_manager->getDefinitions()) as $plugin_id) {
+      /** @var \Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType\PaymentMethodTypeInterface $payment_method_type */
+      $payment_method_type = $payment_method_type_manager->createInstance($plugin_id);
+      $definitions += $payment_method_type->buildFieldDefinitions();
+    }
+  }
+  elseif ($entity_type->id() == 'commerce_payment') {
+    $payment_gateway_storage = \Drupal::entityTypeManager()->getStorage('commerce_payment_gateway');
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface[] $payment_gateways */
+    $payment_gateways = $payment_gateway_storage->loadMultiple();
+    foreach ($payment_gateways as $payment_gateway) {
+      $definitions += $payment_gateway->getPlugin()->buildPaymentFieldDefinitions();
+    }
+  }
+
+  // Process any found definitions, ensuring the presence of required keys.
+  foreach ($definitions as $field_name => $definition) {
+    $definition->setName($field_name);
+    $definition->setTargetEntityTypeId($entity_type->id());
+    $definitions[$field_name] = $definition;
+  }
+
+  return $definitions;
+}
+
+/**
+ * Implements hook_entity_bundle_field_info().
+ */
+function commerce_payment_entity_bundle_field_info(EntityTypeInterface $entity_type, $bundle) {
+  $definitions = [];
+  if ($entity_type->id() == 'commerce_payment_method') {
+    $payment_method_type_manager = \Drupal::service('plugin.manager.commerce_payment_method_type');
+    /** @var \Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType\PaymentMethodTypeInterface $payment_method_type */
+    $payment_method_type = $payment_method_type_manager->createInstance($bundle);
+    $definitions = $payment_method_type->buildFieldDefinitions();
+  }
+  elseif ($entity_type->id() == 'commerce_payment') {
+    $payment_gateway_storage = \Drupal::entityTypeManager()->getStorage('commerce_payment_gateway');
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface $payment_gateway */
+    $payment_gateway = $payment_gateway_storage->load($bundle);
+    $definitions = $payment_gateway->getPlugin()->buildPaymentFieldDefinitions();
+  }
+
+  // Process any found definitions, ensuring the presence of required keys.
+  foreach ($definitions as $field_name => $definition) {
+    $definition->setName($field_name);
+    $definition->setTargetEntityTypeId($entity_type->id());
+    $definition->setTargetBundle($bundle);
+    $definitions[$field_name] = $definition;
+  }
+
+  return $definitions;
+}
+
+/**
+ * Implements hook_entity_bundle_create().
+ */
+function commerce_payment_entity_bundle_create($entity_type_id, $bundle) {
+  if (in_array($entity_type_id, ['commerce_payment', 'commerce_payment_method'])) {
+    $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type_id);
+    $definitions = commerce_payment_entity_bundle_field_info($entity_type, $bundle);
+    commerce_payment_create_field_definitions($definitions);
+  }
+}
+
+/**
+ * Implements hook_entity_bundle_delete().
+ */
+function commerce_payment_entity_bundle_delete($entity_type_id, $bundle) {
+  if (in_array($entity_type_id, ['commerce_payment', 'commerce_payment_method'])) {
+    $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type_id);
+    $definitions = commerce_payment_entity_bundle_field_info($entity_type, $bundle);
+    commerce_payment_delete_field_definitions($definitions);
+  }
+}
+
+/**
+ * Creates the given field definitions.
+ *
+ * @param array $definitions
+ *   The field definitions.
+ */
+function commerce_payment_create_field_definitions(array $definitions) {
+  $field_storage_definition_listener = \Drupal::service('field_storage_definition.listener');
+  $field_definition_listener = \Drupal::service('field_definition.listener');
+  foreach ($definitions as $definition) {
+    $field_storage_definition_listener->onFieldStorageDefinitionCreate($definition);
+    $field_definition_listener->onFieldDefinitionCreate($definition);
+  }
+}
+
+/**
+ * Deletes the given field definitions.
+ *
+ * @param array $definitions
+ *   The field definitions.
+ */
+function commerce_payment_delete_field_definitions(array $definitions) {
+  $field_storage_definition_listener = \Drupal::service('field_storage_definition.listener');
+  $field_definition_listener = \Drupal::service('field_definition.listener');
+  foreach ($definitions as $definition) {
+    $field_storage_definition_listener->onFieldStorageDefinitionDelete($definition);
+    $field_definition_listener->onFieldDefinitionDelete($definition);
+  }
+}

--- a/modules/payment/commerce_payment.permissions.yml
+++ b/modules/payment/commerce_payment.permissions.yml
@@ -1,0 +1,7 @@
+administer payment gateways:
+  title: 'Administer payment gateways'
+  'restrict access': TRUE
+
+administer payments:
+  title: 'Administer payments'
+  'restrict access': TRUE

--- a/modules/payment/commerce_payment.routing.yml
+++ b/modules/payment/commerce_payment.routing.yml
@@ -1,0 +1,7 @@
+entity.commerce_payment_gateway.collection:
+  path: '/admin/commerce/config/payment-gateways'
+  defaults:
+    _entity_list: 'commerce_payment_gateway'
+    _title: 'Payment gateways'
+  requirements:
+    _permission: 'administer payment gateways'

--- a/modules/payment/commerce_payment.services.yml
+++ b/modules/payment/commerce_payment.services.yml
@@ -1,0 +1,8 @@
+services:
+  plugin.manager.commerce_payment_gateway:
+    class: Drupal\commerce_payment\PaymentGatewayManager
+    parent: default_plugin_manager
+
+  plugin.manager.commerce_payment_method_type:
+    class: Drupal\commerce_payment\PaymentMethodTypeManager
+    parent: default_plugin_manager

--- a/modules/payment/commerce_payment.workflow_groups.yml
+++ b/modules/payment/commerce_payment.workflow_groups.yml
@@ -1,0 +1,3 @@
+payment:
+  label: Payment
+  entity_type: commerce_payment

--- a/modules/payment/commerce_payment.workflows.yml
+++ b/modules/payment/commerce_payment.workflows.yml
@@ -1,0 +1,40 @@
+payment_default:
+  id: payment_default
+  group: payment
+  label: 'Default'
+  states:
+    new:
+      label: New
+    authorization:
+      label: 'Authorization'
+    authorization_void:
+      label: 'Authorization (Voided)'
+    authorization_expired:
+      label: 'Authorization (Expired)'
+    capture_completed:
+      label: Capture (Completed)
+    capture_partally_refunded:
+      label: Capture (Partially refunded)
+    capture_refunded:
+      label: Capture (Refunded)
+  transitions:
+    authorize:
+      label: 'Authorize payment'
+      from: [new]
+      to: authorization
+    void:
+      label: 'Void payment'
+      from: [authorization]
+      to: authorization_void
+    capture:
+      label: 'Capture payment'
+      from: [pending]
+      to: completed
+    charge:
+      label: 'Charge payment'
+      from: [new]
+      to: completed
+    refund:
+      label: 'Refund payment'
+      from: [capture_completed]
+      to: refunded

--- a/modules/payment/config/schema/commerce_payment.schema.yml
+++ b/modules/payment/config/schema/commerce_payment.schema.yml
@@ -1,0 +1,33 @@
+commerce_payment.commerce_payment_gateway.*:
+  type: config_entity
+  label: 'Payment gateway'
+  mapping:
+    id:
+      type: string
+      label: 'Machine-readable name'
+    label:
+      type: label
+      label: 'Label'
+    weight:
+      type: integer
+      label: 'Weight'
+    plugin:
+      type: string
+      label: 'Plugin'
+    configuration:
+      type: commerce_payment.commerce_payment_gateway.plugin.[%parent.plugin]
+
+commerce_payment.commerce_payment_gateway.plugin.*:
+  type: commerce_payment_gateway_configuration
+
+commerce_payment_gateway_configuration:
+  type: mapping
+  mapping:
+    mode:
+      type: string
+      label: 'Mode'
+    payment_method_types:
+      type: sequence
+      label: 'Payment method types'
+      sequence:
+        type: string

--- a/modules/payment/src/Annotation/CommercePaymentGateway.php
+++ b/modules/payment/src/Annotation/CommercePaymentGateway.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\commerce_payment\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines the payment gateway plugin annotation object.
+ *
+ * Plugin namespace: Plugin\Commerce\PaymentGateway
+ *
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class CommercePaymentGateway extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The payment gateway label.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $label;
+
+  /**
+   * The payment gateway display label.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $display_label;
+
+  /**
+   * The supported modes.
+   *
+   * An array of mode labels keyed by machine name.
+   *
+   * @var string[]
+   */
+  public $modes;
+
+  /**
+   * The payment gateway forms.
+   *
+   * An array of form classes keyed by form ID.
+   * For example:
+   * <code>
+   *   'add-payment-method' => "Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\Form\PaymentMethodAddForm",
+   *   'capture-payment' => "Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\Form\PaymentCaptureForm",
+   * </code>
+   *
+   * @var array
+   */
+  public $forms = [];
+
+  /**
+   * The payment method types handled by the payment gateway.
+   *
+   * @var string[]
+   */
+  public $payment_method_types = [];
+
+  /**
+   * The payment workflow.
+   *
+   * @var string
+   */
+  public $workflow = 'payment_default';
+
+  /**
+   * Constructs a new CommercePaymentGateway object.
+   *
+   * @param array $values
+   *   The annotation values.
+   */
+  public function __construct($values) {
+    // Define default modes.
+    if (empty($values['modes'])) {
+      $values['modes'] = [
+        'test' => t('Test'),
+        'live' => t('Live'),
+      ];
+    }
+    parent::__construct($values);
+  }
+
+}

--- a/modules/payment/src/Annotation/CommercePaymentMethodType.php
+++ b/modules/payment/src/Annotation/CommercePaymentMethodType.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\commerce_payment\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines the payment method type plugin annotation object.
+ *
+ * Plugin namespace: Plugin\Commerce\PaymentMethodType
+ *
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class CommercePaymentMethodType extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The payment method type label.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $label;
+
+  /**
+   * The payment method type create label.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $create_label;
+
+}

--- a/modules/payment/src/CreditCard.php
+++ b/modules/payment/src/CreditCard.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Drupal\commerce_payment;
+
+/**
+ * Provides logic for listing card types and validating card details.
+ */
+final class CreditCard {
+
+  /**
+   * The instantiated credit card types.
+   *
+   * @var \Drupal\commerce_payment\CreditCardType[]
+   */
+  public static $types = [];
+
+  /**
+   * Gets the credit card type with the given ID.
+   *
+   * @param string $id
+   *   The credit card type ID. For example: 'visa'.
+   *
+   * @return \Drupal\commerce_payment\CreditCardType
+   *   The credit card type.
+   */
+  public static function getType($id) {
+    $types = self::getTypes();
+    if (!isset($types[$id])) {
+      throw new \InvalidArgumentException(sprintf('Invalid credit card type "%s"', $id));
+    }
+
+    return $types[$id];
+  }
+
+  /**
+   * Gets all available credit card types.
+   *
+   * @return \Drupal\commerce_payment\CreditCardType[]
+   *   The credit card types.
+   */
+  public static function getTypes() {
+    $definitions = [
+      'visa' => [
+        'id' => 'visa',
+        'label' => t('Visa'),
+        'number_prefixes' => ['4'],
+      ],
+      'mastercard' => [
+        'id' => 'mastercard',
+        'label' => t('MasterCard'),
+        'number_prefixes' => ['51-55', '222100-272099'],
+      ],
+      'amex' => [
+        'id' => 'amex',
+        'label' => t('American Express'),
+        'number_prefixes' => ['34', '37'],
+        'number_lengths' => [15],
+        'security_code_length' => 4,
+      ],
+      'dinersclub' => [
+        'id' => 'dinersclub',
+        'label' => t('Diners Club'),
+        'number_prefixes' => ['300-305', '309', '36', '38', '39'],
+        'number_lengths' => [14],
+      ],
+      'discover' => [
+        'id' => 'discover',
+        'label' => t('Discover Card'),
+        'number_prefixes' => ['6011', '622126-622925', '644-649', '65'],
+        'number_lengths' => [16, 19],
+      ],
+      'jcb' => [
+        'id' => 'jcb',
+        'label' => t('JCB'),
+        'number_prefixes' => ['3528-3589'],
+      ],
+      'unionpay' => [
+        'id' => 'unionpay',
+        'label' => t('UnionPay'),
+        'number_prefixes' => ['62', '88'],
+        'number_lengths' => [16, 17, 18, 19],
+        'uses_luhn' => FALSE,
+      ],
+      'maestro' => [
+        'id' => 'maestro',
+        'label' => t('Maestro'),
+        'number_prefixes' => ['5018', '5020', '5038', '5612', '5893', '6304',
+                              '6759', '6761', '6762', '6763', '0604', '6390'],
+        'number_lengths' => [12, 13, 14, 15, 16, 17, 18, 19],
+      ],
+    ];
+    foreach ($definitions as $id => $definition) {
+      self::$types[$id] = new CreditCardType($definition);
+    }
+
+    return self::$types;
+  }
+
+  /**
+   * Gets the labels of all available credit card types.
+   *
+   * @return array
+   *   The labels, keyed by ID.
+   */
+  public static function getTypeLabels() {
+    $types = self::getTypes();
+    $type_labels = array_map(function ($type) {
+      return $type->getLabel();
+    }, $types);
+
+    return $type_labels;
+  }
+
+  /**
+   * Detects the credit card type based on the number.
+   *
+   * @param string $number
+   *   The credit card number.
+   *
+   * @return \Drupal\commerce_payment\CreditCardType|null
+   *   The credit card type, or NULL if unknown.
+   */
+  public static function detectType($number) {
+    if (!is_numeric($number)) {
+      return FALSE;
+    }
+    $types = self::getTypes();
+    foreach ($types as $type) {
+      foreach ($type->getNumberPrefixes() as $prefix) {
+        if (self::matchPrefix($number, $prefix)) {
+          return $type;
+        }
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Checks whether the given credit card number matches the given prefix.
+   *
+   * @param string $number
+   *   The credit card number.
+   * @param string $prefix
+   *   The prefix to match against. Can be a single number such as '43' or a
+   *   range such as '30-35'.
+   *
+   * @return bool
+   *   TRUE if the credit card number matches the prefix, FALSE otherwise.
+   */
+  public static function matchPrefix($number, $prefix) {
+    if (is_numeric($prefix)) {
+      return substr($number, 0, strlen($prefix)) == $prefix;
+    }
+    else {
+      list($start, $end) = explode('-', $prefix);
+      $number = substr($number, 0, strlen($start));
+      return $number >= $start && $number <= $end;
+    }
+  }
+
+  /**
+   * Validates the given credit card number.
+   *
+   * @param string $number
+   *   The credit card number.
+   * @param \Drupal\commerce_payment\CreditCardType $type
+   *   The credit card type.
+   *
+   * @return bool
+   *   TRUE if the credit card number is valid, FALSE otherwise.
+   */
+  public static function validateNumber($number, CreditCardType $type) {
+    if (!is_numeric($number)) {
+      return FALSE;
+    }
+    if (!in_array(strlen($number), $type->getNumberLengths())) {
+      return FALSE;
+    }
+    if ($type->usesLuhn() && !self::validateLuhn($number)) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Validates the given credit card number using the Luhn algorithm.
+   *
+   * @param string $number
+   *   The credit card number.
+   *
+   * @return bool
+   *   TRUE if the credit card number is valid, FALSE otherwise.
+   */
+  public static function validateLuhn($number) {
+    $total = 0;
+    foreach (array_reverse(str_split($number)) as $i => $digit) {
+      $digit = $i % 2 ? $digit * 2 : $digit;
+      $digit = $digit > 9 ? $digit - 9 : $digit;
+      $total += $digit;
+    }
+    return ($total % 10 === 0);
+  }
+
+  /**
+   * Validates the given credit card security code.
+   *
+   * @param string $security_code
+   *   The credit card security code.
+   * @param \Drupal\commerce_payment\CreditCardType $type
+   *   The credit card type.
+   *
+   * @return bool
+   *   TRUE if the credit card security code is valid, FALSE otherwise.
+   */
+  public static function validateSecurityCode($security_code, CreditCardType $type) {
+    if (!is_numeric($security_code)) {
+      return FALSE;
+    }
+    if (strlen($security_code) != $type->getSecurityCodeLength()) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/modules/payment/src/CreditCardType.php
+++ b/modules/payment/src/CreditCardType.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Drupal\commerce_payment;
+
+/**
+ * Represents a credit card type.
+ */
+final class CreditCardType {
+
+  /**
+   * The credit card type ID.
+   *
+   * @var string
+   */
+  protected $id;
+
+  /**
+   * The credit card type label.
+   *
+   * @var string
+   */
+  protected $label;
+
+  /**
+   * The credit card type number prefixes.
+   *
+   * @var array
+   */
+  protected $numberPrefixes;
+
+  /**
+   * The credit card type number lengths.
+   *
+   * @var array
+   */
+  protected $numberLengths = [16];
+
+  /**
+   * The credit card type security code length.
+   *
+   * @var string
+   */
+  protected $securityCodeLength = 3;
+
+  /**
+   * Whether the credit cart type uses Luhn validation.
+   *
+   * @var string
+   */
+  protected $usesLuhn = TRUE;
+
+  /**
+   * Constructs a new CreditCardType instance.
+   *
+   * @param array $definition
+   *   The definition.
+   */
+  public function __construct(array $definition) {
+    foreach (['id', 'label', 'number_prefixes'] as $required_property) {
+      if (empty($definition[$required_property])) {
+        throw new \InvalidArgumentException(sprintf('Missing required property %s.', $required_property));
+      }
+    }
+
+    $this->id = $definition['id'];
+    $this->label = $definition['label'];
+    $this->numberPrefixes = $definition['number_prefixes'];
+    if (isset($definition['number_lengths'])) {
+      $this->numberLengths = $definition['number_lengths'];
+    }
+    if (isset($definition['security_code_length'])) {
+      $this->securityCodeLength = $definition['security_code_length'];
+    }
+    if (isset($definition['uses_luhn'])) {
+      $this->usesLuhn = $definition['uses_luhn'];
+    }
+  }
+
+  /**
+   * Gets the credit card type ID.
+   *
+   * @return string
+   *   The credit card type ID.
+   */
+  public function getId() {
+    return $this->id;
+  }
+
+  /**
+   * Gets the credit card type label.
+   *
+   * @return string
+   *   The credit card type label.
+   */
+  public function getLabel() {
+    return $this->label;
+  }
+
+  /**
+   * Gets the credit card type number prefixes.
+   *
+   * @return array
+   *   The credit card type number prefixes.
+   */
+  public function getNumberPrefixes() {
+    return $this->numberPrefixes;
+  }
+
+  /**
+   * Gets the credit card type number lengths.
+   *
+   * @return array
+   *   The credit card type number lengths.
+   */
+  public function getNumberLengths() {
+    return $this->numberLengths;
+  }
+
+  /**
+   * Gets the credit card type security code length.
+   *
+   * @return string
+   *   The credit card type security code length.
+   */
+  public function getSecurityCodeLength() {
+    return $this->securityCodeLength;
+  }
+
+  /**
+   * Gets whether the credit card type uses Luhn validation.
+   *
+   * @return bool
+   *   TRUE if the credit card type uses Luhn validation, FALSE otherwise.
+   */
+  public function usesLuhn() {
+    return $this->usesLuhn;
+  }
+
+}

--- a/modules/payment/src/Entity/Payment.php
+++ b/modules/payment/src/Entity/Payment.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Drupal\commerce_payment\Entity;
+
+use Drupal\commerce_price\Price;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Defines the payment entity class.
+ *
+ * @ContentEntityType(
+ *   id = "commerce_payment",
+ *   label = @Translation("Payment"),
+ *   label_singular = @Translation("Payment"),
+ *   label_plural = @Translation("Payments"),
+ *   label_count = @PluralTranslation(
+ *     singular = "@count payment",
+ *     plural = "@count payments",
+ *   ),
+ *   bundle_label = @Translation("Payment gateway"),
+ *   handlers = {
+ *     "storage" = "Drupal\commerce\CommerceContentEntityStorage",
+ *     "views_data" = "Drupal\views\EntityViewsData",
+ *   },
+ *   base_table = "commerce_payment",
+ *   admin_permission = "administer payments",
+ *   fieldable = TRUE,
+ *   entity_keys = {
+ *     "id" = "payment_id",
+ *     "bundle" = "payment_gateway",
+ *     "uuid" = "uuid",
+ *   },
+ *   bundle_entity_type = "commerce_payment_gateway",
+ * )
+ */
+class Payment extends ContentEntityBase implements PaymentInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentGateway() {
+    return $this->get('payment_gateway')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentGatewayId() {
+    return $this->bundle();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentMethod() {
+    return $this->get('payment_method')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentMethodId() {
+    return $this->get('payment_method')->target_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOrder() {
+    return $this->get('order_id')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOrderId() {
+    return $this->get('order_id')->target_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRemoteId() {
+    return $this->get('remote_id')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRemoteId($remote_id) {
+    $this->set('remote_id', $remote_id);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAmount() {
+    return $this->get('amount')->first()->toPrice();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setAmount(Price $amount) {
+    $this->set('amount', $amount);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRefundedAmount() {
+    return $this->get('refunded_amount')->first()->toPrice();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRefundedAmount(Price $refunded_amount) {
+    $this->set('refunded_amount', $refunded_amount);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getState() {
+    return $this->get('state')->first();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAuthorizedTime() {
+    return $this->get('authorized')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setAuthorizedTime($timestamp) {
+    $this->set('authorized', $timestamp);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAuthorizationExpiresTime() {
+    return $this->get('authorization_expires')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setAuthorizationExpiresTime($timestamp) {
+    $this->set('authorization_expires', $timestamp);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCapturedTime() {
+    return $this->get('captured')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCapturedTime($timestamp) {
+    $this->set('captured', $timestamp);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['payment_method'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Payment method'))
+      ->setDescription(t('The payment method.'))
+      ->setSetting('target_type', 'commerce_payment_method')
+      ->setReadOnly(TRUE);
+
+    // The order backreference, populated by Order::postSave().
+    $fields['order_id'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Order'))
+      ->setDescription(t('The parent order.'))
+      ->setSetting('target_type', 'commerce_order')
+      ->setReadOnly(TRUE);
+
+    $fields['remote_id'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Remote ID'))
+      ->setDescription(t('The remote payment ID.'))
+      ->setSetting('max_length', 255)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['amount'] = BaseFieldDefinition::create('commerce_price')
+      ->setLabel(t('Amount'))
+      ->setDescription(t('The payment amount.'))
+      ->setRequired(TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['refunded_amount'] = BaseFieldDefinition::create('commerce_price')
+      ->setLabel(t('Refunded amount'))
+      ->setDescription(t('The refunded payment amount.'))
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['state'] = BaseFieldDefinition::create('state')
+      ->setLabel(t('State'))
+      ->setDescription(t('The payment state.'))
+      ->setRequired(TRUE)
+      ->setSetting('max_length', 255)
+      ->setDisplayOptions('view', [
+        'label' => 'hidden',
+        'type' => 'list_default',
+        'weight' => 0,
+      ])
+      ->setDisplayConfigurable('view', TRUE)
+      ->setSetting('workflow_callback', ['\Drupal\commerce_payment\Entity\Payment', 'getWorkflowId']);
+
+    $fields['authorized'] = BaseFieldDefinition::create('timestamp')
+      ->setLabel(t('Authorized'))
+      ->setDescription(t('The time when the payment was authorized.'))
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['authorization_expires'] = BaseFieldDefinition::create('timestamp')
+      ->setLabel(t('Authorization expires'))
+      ->setDescription(t('The time when the payment authorization expires.'))
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['captured'] = BaseFieldDefinition::create('timestamp')
+      ->setLabel(t('Captured'))
+      ->setDescription(t('The time when the payment was captured.'))
+      ->setDisplayConfigurable('view', TRUE);
+
+    return $fields;
+  }
+
+  /**
+   * Gets the workflow ID for the state field.
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentInterface $payment
+   *   The payment.
+   *
+   * @return string
+   *   The workflow ID.
+   */
+  public static function getWorkflowId(PaymentInterface $payment) {
+    return $payment->getPaymentGateway()->getPlugin()->getWorkflowId();
+  }
+
+}

--- a/modules/payment/src/Entity/PaymentGateway.php
+++ b/modules/payment/src/Entity/PaymentGateway.php
@@ -196,7 +196,7 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
 
     $bundle_of = $this->getEntityType()->getBundleOf();
     if (!$update) {
-      \Drupal::getContainer()->get('entity_bundle.listener')->onBundleCreate($this->id(), $bundle_of);
+      \Drupal::service('entity_bundle.listener')->onBundleCreate($this->id(), $bundle_of);
     }
     else {
       $entity_field_manager = \Drupal::getContainer()->get('entity_field.manager');
@@ -213,7 +213,7 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
     parent::preDelete($storage, $entities);
 
     foreach ($entities as $entity) {
-      \Drupal::getContainer()->get('entity_bundle.listener')->onBundleDelete($entity->id(), $entity->getEntityType()->getBundleOf());
+      \Drupal::service('entity_bundle.listener')->onBundleDelete($entity->id(), $entity->getEntityType()->getBundleOf());
     }
   }
 

--- a/modules/payment/src/Entity/PaymentGateway.php
+++ b/modules/payment/src/Entity/PaymentGateway.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Drupal\commerce_payment\Entity;
+
+use Drupal\commerce_payment\PaymentGatewayPluginCollection;
+use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
+
+/**
+ * Defines the payment gateway entity class.
+ *
+ * @ConfigEntityType(
+ *   id = "commerce_payment_gateway",
+ *   label = @Translation("Payment gateway"),
+ *   label_singular = @Translation("Payment gateway"),
+ *   label_plural = @Translation("Payment gateways"),
+ *   label_count = @PluralTranslation(
+ *     singular = "@count payment gateway",
+ *     plural = "@count payment gateways",
+ *   ),
+ *   handlers = {
+ *     "list_builder" = "Drupal\commerce_payment\PaymentGatewayListBuilder",
+ *     "form" = {
+ *       "add" = "Drupal\commerce_payment\Form\PaymentGatewayForm",
+ *       "edit" = "Drupal\commerce_payment\Form\PaymentGatewayForm",
+ *       "delete" = "Drupal\Core\Entity\EntityDeleteForm"
+ *     },
+ *     "route_provider" = {
+ *       "default" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
+ *     },
+ *   },
+ *   admin_permission = "administer payment gateways",
+ *   config_prefix = "commerce_payment_gateway",
+ *   bundle_of = "commerce_payment",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "label",
+ *     "uuid" = "uuid",
+ *     "weight" = "weight",
+ *   },
+ *   config_export = {
+ *     "id",
+ *     "label",
+ *     "weight",
+ *     "plugin",
+ *     "configuration",
+ *   },
+ *   links = {
+ *     "add-form" = "/admin/commerce/config/payment-gateways/add",
+ *     "edit-form" = "/admin/commerce/config/payment-gateways/manage/{commerce_payment_gateway}",
+ *     "delete-form" = "/admin/commerce/config/payment-gateways/manage/{commerce_payment_gateway}/delete",
+ *     "collection" =  "/admin/commerce/config/payment-gateways"
+ *   }
+ * )
+ */
+class PaymentGateway extends ConfigEntityBundleBase implements PaymentGatewayInterface {
+
+  /**
+   * The payment gateway ID.
+   *
+   * @var string
+   */
+  protected $id;
+
+  /**
+   * The payment gateway label.
+   *
+   * @var string
+   */
+  protected $label;
+
+  /**
+   * The payment gateway weight.
+   *
+   * @var int
+   */
+  protected $weight;
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  protected $plugin;
+
+  /**
+   * The plugin configuration.
+   *
+   * @var array
+   */
+  protected $configuration = [];
+
+  /**
+   * The plugin collection that holds the payment gateway plugin.
+   *
+   * @var \Drupal\commerce_payment\PaymentGatewayPluginCollection
+   */
+  protected $pluginCollection;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getWeight() {
+    return $this->weight;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setWeight($weight) {
+    $this->weight = $weight;
+    return $weight;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPlugin() {
+    return $this->getPluginCollection()->get($this->plugin);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginId() {
+    return $this->plugin;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setPluginId($plugin_id) {
+    $this->plugin = $plugin_id;
+    $this->pluginCollection = NULL;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginCollections() {
+    return [
+      'configuration' => $this->getPluginCollection(),
+    ];
+  }
+
+  /**
+   * Gets the plugin collection that holds the payment gateway plugin.
+   *
+   * Ensures the plugin collection is initialized before returning it.
+   *
+   * @return \Drupal\commerce_payment\PaymentGatewayPluginCollection
+   *   The plugin collection.
+   */
+  protected function getPluginCollection() {
+    if (!$this->pluginCollection) {
+      $plugin_manager = \Drupal::service('plugin.manager.commerce_payment_gateway');
+      $this->pluginCollection = new PaymentGatewayPluginCollection($plugin_manager, $this->plugin, $this->configuration, $this->id);
+    }
+    return $this->pluginCollection;
+  }
+
+}

--- a/modules/payment/src/Entity/PaymentGateway.php
+++ b/modules/payment/src/Entity/PaymentGateway.php
@@ -199,7 +199,7 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
       \Drupal::service('entity_bundle.listener')->onBundleCreate($this->id(), $bundle_of);
     }
     else {
-      $entity_field_manager = \Drupal::getContainer()->get('entity_field.manager');
+      $entity_field_manager = \Drupal::service('entity_field.manager');
       // Entity bundle field definitions may depend on bundle settings.
       $entity_field_manager->clearCachedFieldDefinitions();
       $entity_field_manager->clearCachedBundles();

--- a/modules/payment/src/Entity/PaymentGateway.php
+++ b/modules/payment/src/Entity/PaymentGateway.php
@@ -199,10 +199,13 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
       \Drupal::service('entity_bundle.listener')->onBundleCreate($this->id(), $bundle_of);
     }
     else {
+      /** @var \Drupal\Core\Entity\EntityFieldManager $entity_field_manager */
       $entity_field_manager = \Drupal::service('entity_field.manager');
       // Entity bundle field definitions may depend on bundle settings.
       $entity_field_manager->clearCachedFieldDefinitions();
-      $entity_field_manager->clearCachedBundles();
+      /** @var \Drupal\Core\Entity\EntityTypeBundleInfo $entity_type_bundle_info */
+      $entity_type_bundle_info = \Drupal::service('entity_type.bundle.info');
+      $entity_type_bundle_info->clearCachedBundles();
     }
   }
 

--- a/modules/payment/src/Entity/PaymentGateway.php
+++ b/modules/payment/src/Entity/PaymentGateway.php
@@ -162,42 +162,6 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
-    parent::postSave($storage, $update);
-
-    $bundle_of = $this->getEntityType()->getBundleOf();
-    if (!$update) {
-      \Drupal::getContainer()->get('entity_bundle.listener')->onBundleCreate($this->id(), $bundle_of);
-    }
-    else {
-      $entity_field_manager = \Drupal::getContainer()->get('entity_field.manager');
-      // Entity bundle field definitions may depend on bundle settings.
-      $entity_field_manager->clearCachedFieldDefinitions();
-      $entity_field_manager->clearCachedBundles();
-    }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function preDelete(EntityStorageInterface $storage, array $entities) {
-    parent::preDelete($storage, $entities);
-    
-    foreach ($entities as $entity) {
-      \Drupal::getContainer()->get('entity_bundle.listener')->onBundleDelete($entity->id(), $entity->getEntityType()->getBundleOf());
-    }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function postDelete(EntityStorageInterface $storage, array $entities) {
-    parent::postDelete($storage, $entities);
-  }
-
-  /**
    * Acts on an entity before the presave hook is invoked.
    *
    * Used before the entity is saved and before invoking the presave hook.
@@ -222,6 +186,42 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
         throw new ConfigNameException("The machine name of the '{$bundle_type->getLabel()}' bundle cannot be changed.");
       }
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+    parent::postSave($storage, $update);
+
+    $bundle_of = $this->getEntityType()->getBundleOf();
+    if (!$update) {
+      \Drupal::getContainer()->get('entity_bundle.listener')->onBundleCreate($this->id(), $bundle_of);
+    }
+    else {
+      $entity_field_manager = \Drupal::getContainer()->get('entity_field.manager');
+      // Entity bundle field definitions may depend on bundle settings.
+      $entity_field_manager->clearCachedFieldDefinitions();
+      $entity_field_manager->clearCachedBundles();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function preDelete(EntityStorageInterface $storage, array $entities) {
+    parent::preDelete($storage, $entities);
+
+    foreach ($entities as $entity) {
+      \Drupal::getContainer()->get('entity_bundle.listener')->onBundleDelete($entity->id(), $entity->getEntityType()->getBundleOf());
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function postDelete(EntityStorageInterface $storage, array $entities) {
+    parent::postDelete($storage, $entities);
   }
 
 }

--- a/modules/payment/src/Entity/PaymentGatewayInterface.php
+++ b/modules/payment/src/Entity/PaymentGatewayInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\commerce_payment\Entity;
+
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+use Drupal\Core\Entity\EntityWithPluginCollectionInterface;
+
+/**
+ * Defines the interface for payment gateway configuration entities.
+ *
+ * Stores configuration for payment gateway plugins.
+ */
+interface PaymentGatewayInterface extends ConfigEntityInterface, EntityWithPluginCollectionInterface {
+
+  /**
+   * Gets the payment gateway weight.
+   *
+   * @return string
+   *   The payment gateway weight.
+   */
+  public function getWeight();
+
+  /**
+   * Sets the payment gateway weight.
+   *
+   * @param int $weight
+   *   The payment gateway weight.
+   *
+   * @return $this
+   */
+  public function setWeight($weight);
+
+  /**
+   * Gets the payment gateway plugin.
+   *
+   * @return \Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\PaymentGatewayInterface
+   *   The payment gateway plugin.
+   */
+  public function getPlugin();
+
+  /**
+   * Gets the payment gateway plugin ID.
+   *
+   * @return string
+   *   The payment gateway plugin ID.
+   */
+  public function getPluginId();
+
+  /**
+   * Sets the payment gateway plugin ID.
+   *
+   * @param string $plugin_id
+   *   The payment gateway plugin ID.
+   *
+   * @return $this
+   */
+  public function setPluginId($plugin_id);
+
+}

--- a/modules/payment/src/Entity/PaymentInterface.php
+++ b/modules/payment/src/Entity/PaymentInterface.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Drupal\commerce_payment\Entity;
+
+use Drupal\commerce_price\Price;
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Defines the interface for payments.
+ */
+interface PaymentInterface extends ContentEntityInterface {
+
+  /**
+   * Gets the payment gateway.
+   *
+   * @return \Drupal\commerce_payment\Entity\PaymentGatewayInterface|null
+   *   The payment gateway entity, or null if unknown.
+   */
+  public function getPaymentGateway();
+
+  /**
+   * Gets the payment gateway ID.
+   *
+   * @return int|null
+   *   The payment gateway ID, or null if unknown.
+   */
+  public function getPaymentGatewayId();
+
+  /**
+   * Gets the payment method.
+   *
+   * @return \Drupal\commerce_payment\Entity\PaymentMethodInterface|null
+   *   The payment method entity, or null if unknown.
+   */
+  public function getPaymentMethod();
+
+  /**
+   * Gets the payment method ID.
+   *
+   * @return int|null
+   *   The payment method ID, or null if unknown.
+   */
+  public function getPaymentMethodId();
+
+  /**
+   * Gets the parent order.
+   *
+   * @return \Drupal\commerce_order\Entity\OrderInterface|null
+   *   The order entity, or null.
+   */
+  public function getOrder();
+
+  /**
+   * Gets the parent order ID.
+   *
+   * @return int|null
+   *   The order ID, or null.
+   */
+  public function getOrderId();
+
+  /**
+   * Gets the payment remote ID
+   *
+   * @return string
+   *   The payment remote ID.
+   */
+  public function getRemoteId();
+
+  /**
+   * Sets the payment remote ID.
+   *
+   * @param string $remote_ID
+   *   The payment remote ID.
+   *
+   * @return $this
+   */
+  public function setRemoteId($remote_ID);
+
+  /**
+   * Gets the payment amount.
+   *
+   * @return \Drupal\commerce_price\Price
+   *   The payment amount.
+   */
+  public function getAmount();
+
+  /**
+   * Sets the payment amount.
+   *
+   * @param \Drupal\commerce_price\Price $amount
+   *   The payment amount.
+   *
+   * @return $this
+   */
+  public function setAmount(Price $amount);
+
+  /**
+   * Gets the refunded payment amount.
+   *
+   * @return \Drupal\commerce_price\Price
+   *   The refunded payment amount.
+   */
+  public function getRefundedAmount();
+
+  /**
+   * Sets the refunded payment amount.
+   *
+   * @param \Drupal\commerce_price\Price $refunded_amount
+   *   The refunded payment amount.
+   *
+   * @return $this
+   */
+  public function setRefundedAmount(Price $refunded_amount);
+
+  /**
+   * Gets the payment state.
+   *
+   * @return \Drupal\state_machine\Plugin\Field\FieldType\StateItemInterface
+   *   The payment state.
+   */
+  public function getState();
+
+  /**
+   * Gets the payment authorization timestamp.
+   *
+   * @return int
+   *   The payment authorization timestamp.
+   */
+  public function getAuthorizedTime();
+
+  /**
+   * Sets the payment authorization timestamp.
+   *
+   * @param int $timestamp
+   *   The payment authorization timestamp.
+   *
+   * @return $this
+   */
+  public function setAuthorizedTime($timestamp);
+
+  /**
+   * Gets the payment authorization expiration timestamp.
+   *
+   * @return int
+   *   The payment authorization expiration timestamp.
+   */
+  public function getAuthorizationExpiresTime();
+
+  /**
+   * Sets the payment authorization expiration timestamp.
+   *
+   * @param int $timestamp
+   *   The payment authorization expiration timestamp.
+   *
+   * @return $this
+   */
+  public function setAuthorizationExpiresTime($timestamp);
+
+  /**
+   * Gets the payment capture timestamp.
+   *
+   * @return int
+   *   The payment capture timestamp.
+   */
+  public function getCapturedTime();
+
+  /**
+   * Sets the payment capture timestamp.
+   *
+   * @param int $timestamp
+   *   The payment capture timestamp.
+   *
+   * @return $this
+   */
+  public function setCapturedTime($timestamp);
+
+}

--- a/modules/payment/src/Entity/PaymentMethod.php
+++ b/modules/payment/src/Entity/PaymentMethod.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Drupal\commerce_payment\Entity;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\user\UserInterface;
+use Drupal\profile\Entity\ProfileInterface;
+
+/**
+ * Defines the payment method entity class.
+ *
+ * @ContentEntityType(
+ *   id = "commerce_payment_method",
+ *   label = @Translation("Payment method"),
+ *   label_singular = @Translation("Payment method"),
+ *   label_plural = @Translation("Payment methods"),
+ *   label_count = @PluralTranslation(
+ *     singular = "@count payment method",
+ *     plural = "@count payment methods",
+ *   ),
+ *   bundle_label = @Translation("Payment method type"),
+ *   handlers = {
+ *     "storage" = "Drupal\commerce\CommerceContentEntityStorage",
+ *   },
+ *   base_table = "commerce_payment_method",
+ *   admin_permission = "administer payments",
+ *   fieldable = TRUE,
+ *   entity_keys = {
+ *     "id" = "method_id",
+ *     "uuid" = "uuid",
+ *     "bundle" = "type"
+ *   },
+ * )
+ */
+class PaymentMethod extends ContentEntityBase implements PaymentMethodInterface {
+
+  use EntityChangedTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label() {
+    return $this->getType()->buildLabel($this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getType() {
+    $payment_method_type_manager = \Drupal::service('plugin.manager.commerce_payment_method_type');
+    return $payment_method_type_manager->createInstance($this->bundle());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentGateway() {
+    return $this->get('payment_gateway')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentGatewayId() {
+    return $this->get('payment_gateway')->target_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOwner() {
+    return $this->get('uid')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOwnerId() {
+    return $this->get('uid')->target_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOwnerId($uid) {
+    $this->set('uid', $uid);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOwner(UserInterface $account) {
+    $this->set('uid', $account->id());
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRemoteId() {
+    return $this->get('remote_id')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRemoteId($remote_id) {
+    $this->set('remote_id', $remote_id);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBillingProfile() {
+    return $this->get('billing_profile')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setBillingProfile(ProfileInterface $profile) {
+    $this->set('billing_profile', $profile->id());
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBillingProfileId() {
+    return $this->get('billing_profile')->target_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setBillingProfileId($billingProfileId) {
+    $this->set('billing_profile', $billingProfileId);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isReusable() {
+    return $this->get('reusable')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setReusable($reusable) {
+    $this->set('reusable', $reusable);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isDefault() {
+    return $this->get('is_default')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setDefault($default) {
+    $this->set('is_default', $default);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getExpiresTime() {
+    return $this->get('expires')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setExpiresTime($timestamp) {
+    $this->set('expires', $timestamp);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCreatedTime() {
+    return $this->get('created')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCreatedTime($timestamp) {
+    $this->set('created', $timestamp);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['payment_gateway'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Payment gateway'))
+      ->setDescription(t('The payment gateway.'))
+      ->setRequired(TRUE)
+      ->setSetting('target_type', 'commerce_payment_gateway');
+
+    $fields['uid'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Owner'))
+      ->setDescription(t('The payment method owner.'))
+      ->setSetting('target_type', 'user')
+      ->setSetting('handler', 'default')
+      ->setDefaultValueCallback('Drupal\commerce_payment\Entity\PaymentMethod::getCurrentUserId')
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'author',
+        'weight' => 0,
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['remote_id'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Remote ID'))
+      ->setDescription(t('The payment method remote ID.'))
+      ->setSetting('max_length', 255)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['billing_profile'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Billing profile'))
+      ->setDescription(t('Billing profile'))
+      ->setSetting('target_type', 'profile')
+      ->setSetting('handler', 'default')
+      ->setSetting('handler_settings', ['target_bundles' => ['billing']])
+      ->setDisplayOptions('form', [
+        'type' => 'options_select',
+        'weight' => 0,
+        'settings' => [],
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['reusable'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Reusable'))
+      ->setDescription(t('Whether the payment method is reusable.'))
+      ->setDefaultValue(TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    // 'default' is a reserved SQL word, hence the 'is_' prefix.
+    $fields['is_default'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Default'))
+      ->setDescription(t("Whether this is the user's default payment method."));
+
+    $fields['expires'] = BaseFieldDefinition::create('timestamp')
+      ->setLabel(t('Expires'))
+      ->setDescription(t('The time when the payment authorization expires.'))
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Created'))
+      ->setDescription(t('The time when the payment was created.'));
+
+    $fields['changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(t('Changed'))
+      ->setDescription(t('The time when the payment was last edited.'));
+
+    return $fields;
+  }
+
+  /**
+   * Default value callback for 'uid' base field definition.
+   *
+   * @see ::baseFieldDefinitions()
+   *
+   * @return array
+   *   An array of default values.
+   */
+  public static function getCurrentUserId() {
+    return [\Drupal::currentUser()->id()];
+  }
+
+}

--- a/modules/payment/src/Entity/PaymentMethodInterface.php
+++ b/modules/payment/src/Entity/PaymentMethodInterface.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Drupal\commerce_payment\Entity;
+
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\user\EntityOwnerInterface;
+use Drupal\profile\Entity\ProfileInterface;
+
+/**
+ * Defines the interface for payment methods.
+ */
+interface PaymentMethodInterface extends EntityChangedInterface, ContentEntityInterface, EntityOwnerInterface {
+
+  /**
+   * Gets the payment method type.
+   *
+   * @return \Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType\PaymentMethodTypeInterface
+   *   The payment method type.
+   */
+  public function getType();
+
+  /**
+   * Gets the payment gateway.
+   *
+   * @return \Drupal\commerce_payment\Entity\PaymentGatewayInterface|null
+   *   The payment gateway entity, or null if unknown.
+   */
+  public function getPaymentGateway();
+
+  /**
+   * Gets the payment gateway ID.
+   *
+   * @return int|null
+   *   The payment gateway ID, or null if unknown.
+   */
+  public function getPaymentGatewayId();
+
+  /**
+   * Gets the payment method remote ID
+   *
+   * @return string
+   *   The payment method remote ID.
+   */
+  public function getRemoteId();
+
+  /**
+   * Sets the payment method remote ID.
+   *
+   * @param string $remote_id
+   *   The payment method remote ID.
+   *
+   * @return $this
+   */
+  public function setRemoteId($remote_id);
+
+  /**
+   * Gets the billing profile.
+   *
+   * @return \Drupal\profile\Entity\ProfileInterface
+   *   The billing profile entity.
+   */
+  public function getBillingProfile();
+
+  /**
+   * Sets the billing profile.
+   *
+   * @param \Drupal\profile\Entity\ProfileInterface $profile
+   *   The billing profile entity.
+   *
+   * @return $this
+   */
+  public function setBillingProfile(ProfileInterface $profile);
+
+  /**
+   * Gets the billing profile ID.
+   *
+   * @return int
+   *   The billing profile ID.
+   */
+  public function getBillingProfileId();
+
+  /**
+   * Sets the billing profile ID.
+   *
+   * @param int $billingProfileId
+   *   The billing profile ID.
+   *
+   * @return $this
+   */
+  public function setBillingProfileId($billingProfileId);
+
+  /**
+   * Gets whether the payment method is reusable.
+   *
+   * @return bool
+   *   TRUE if the payment method is reusable, FALSE otherwise.
+   */
+  public function isReusable();
+
+  /**
+   * Sets whether the payment method is reusable.
+   *
+   * @param bool $reusable
+   *   Whether the payment method is reusable.
+   *
+   * @return $this
+   */
+  public function setReusable($reusable);
+
+  /**
+   * Gets whether this is the user's default payment method.
+   *
+   * @return bool
+   *   TRUE if this is the user's default payment method, FALSE otherwise.
+   */
+  public function isDefault();
+
+  /**
+   * Sets whether this is the user's default payment method.
+   *
+   * @param bool $default
+   *   Whether this is the user's default payment method.
+   *
+   * @return $this
+   */
+  public function setDefault($default);
+
+  /**
+   * Gets the payment method expiration timestamp.
+   *
+   * @return int
+   *   The payment method expiration timestamp.
+   */
+  public function getExpiresTime();
+
+  /**
+   * Sets the payment method expiration timestamp.
+   *
+   * @param int $timestamp
+   *   The payment method expiration timestamp.
+   *
+   * @return $this
+   */
+  public function setExpiresTime($timestamp);
+
+  /**
+   * Gets the payment method creation timestamp.
+   *
+   * @return int
+   *   Creation timestamp of the payment.
+   */
+  public function getCreatedTime();
+
+  /**
+   * Sets the payment method creation timestamp.
+   *
+   * @param int $timestamp
+   *   The payment method creation timestamp.
+   *
+   * @return $this
+   */
+  public function setCreatedTime($timestamp);
+
+}

--- a/modules/payment/src/Form/PaymentGatewayForm.php
+++ b/modules/payment/src/Form/PaymentGatewayForm.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Drupal\commerce_payment\Form;
+
+use Drupal\commerce_payment\PaymentGatewayManager;
+use Drupal\Core\Entity\BundleEntityFormBase;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class PaymentGatewayForm extends BundleEntityFormBase {
+
+  /**
+   * The payment gateway plugin manager.
+   *
+   * @var \Drupal\commerce_payment\PaymentGatewayManager
+   */
+  protected $pluginManager;
+
+  /**
+   * Constructs a new PaymentGatewayForm object.
+   *
+   * @param \Drupal\commerce_payment\PaymentGatewayManager $plugin_manager
+   *   The payment gateway plugin manager.
+   */
+  public function __construct(PaymentGatewayManager $plugin_manager) {
+    $this->pluginManager = $plugin_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.commerce_payment_gateway')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface $gateway */
+    $gateway = $this->entity;
+    $plugins = array_map(function ($definition) {
+      return $definition['label'];
+    }, $this->pluginManager->getDefinitions());
+
+    $form['#tree'] = TRUE;
+    $form['label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Name'),
+      '#maxlength' => 255,
+      '#default_value' => $gateway->label(),
+      '#required' => TRUE,
+    ];
+    $form['id'] = [
+      '#type' => 'machine_name',
+      '#default_value' => $gateway->id(),
+      '#machine_name' => [
+        'exists' => '\Drupal\commerce_payment\Entity\PaymentGateway::load',
+      ],
+    ];
+    $form['plugin'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Plugin'),
+      '#options' => $plugins,
+      '#default_value' => $gateway->getPluginId(),
+      '#required' => TRUE,
+      '#disabled' => !$gateway->isNew(),
+    ];
+    if (!$gateway->isNew()) {
+      $form['configuration'] = [
+        '#parents' => ['configuration'],
+      ];
+      $form['configuration'] = $gateway->getPlugin()->buildConfigurationForm($form['configuration'], $form_state);
+    }
+
+    return $this->protectBundleIdElement($form);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function copyFormValuesToEntity(EntityInterface $entity, array $form, FormStateInterface $form_state) {
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface $entity */
+    // The parent method tries to initialize the plugin collection before
+    // setting the plugin.
+    $entity->setPluginId($form_state->getValue('plugin'));
+
+    parent::copyFormValuesToEntity($entity, $form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface $gateway */
+    $gateway = $this->entity;
+    if (!$gateway->isNew()) {
+      $gateway->getPlugin()->validateConfigurationForm($form['configuration'], $form_state);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface $gateway */
+    $gateway = $this->entity;
+    if (!$gateway->isNew()) {
+      $gateway->getPlugin()->submitConfigurationForm($form['configuration'], $form_state);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $status = $this->entity->save();
+    drupal_set_message($this->t('Saved the %label payment gateway.', ['%label' => $this->entity->label()]));
+    if ($status == SAVED_UPDATED) {
+      $form_state->setRedirect('entity.commerce_payment_gateway.collection');
+    }
+    elseif ($status == SAVED_NEW) {
+      // Send the user to the Edit form to see the plugin configuration form.
+      $form_state->setRedirect('entity.commerce_payment_gateway.edit_form', [
+        'commerce_payment_gateway' => $this->entity->id(),
+      ]);
+    }
+  }
+
+}

--- a/modules/payment/src/PaymentGatewayListBuilder.php
+++ b/modules/payment/src/PaymentGatewayListBuilder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\commerce_payment;
+
+use Drupal\Core\Config\Entity\DraggableListBuilder;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Defines the list builder for payment gateways.
+ */
+class PaymentGatewayListBuilder extends DraggableListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $entitiesKey = 'gateways';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'commerce_payment_gateways';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['label'] = $this->t('Payment gateway');
+    $header['mode'] = $this->t('Mode');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface $entity */
+    $gateway_plugin = $entity->getPlugin();
+    $modes = $gateway_plugin->getSupportedModes();
+    $mode = $modes ? $modes[$gateway_plugin->getMode()] :  $this->t('N/A');
+    $row['label'] = $entity->label();
+    // $this->weightKey determines whether the table will be rendered as a form.
+    if (!empty($this->weightKey)) {
+      $row['mode']['#markup'] = $mode;
+    }
+    else {
+      $row['mode'] = $mode;
+    }
+
+    return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $entities = $this->load();
+    // If there are less than 2 gateways, disable dragging.
+    if (count($entities) <= 1) {
+      unset($this->weightKey);
+    }
+    return parent::render();
+  }
+
+}

--- a/modules/payment/src/PaymentGatewayManager.php
+++ b/modules/payment/src/PaymentGatewayManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\commerce_payment;
+
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Manages discovery and instantiation of payment gateway plugins.
+ *
+ * @see \Drupal\commerce_payment\Annotation\CommercePaymentGateway
+ * @see plugin_api
+ */
+class PaymentGatewayManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a new PaymentGatewayManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/Commerce/PaymentGateway', $namespaces, $module_handler, 'Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\PaymentGatewayInterface', 'Drupal\commerce_payment\Annotation\CommercePaymentGateway');
+
+    $this->alterInfo('commerce_payment_gateway_info');
+    $this->setCacheBackend($cache_backend, 'commerce_payment_gateway_plugins');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processDefinition(&$definition, $plugin_id) {
+    parent::processDefinition($definition, $plugin_id);
+
+    foreach (['id', 'label', 'display_label'] as $required_property) {
+      if (empty($definition[$required_property])) {
+        throw new PluginException(sprintf('The payment gateway %s must define the %s property.', $plugin_id, $required_property));
+      }
+    }
+  }
+
+}

--- a/modules/payment/src/PaymentGatewayPluginCollection.php
+++ b/modules/payment/src/PaymentGatewayPluginCollection.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\commerce_payment;
+
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\Core\Plugin\DefaultSingleLazyPluginCollection;
+
+/**
+ * A collection of payment gateway plugins.
+ */
+class PaymentGatewayPluginCollection extends DefaultSingleLazyPluginCollection {
+
+  /**
+   * The payment gateway entity ID this plugin collection belongs to.
+   *
+   * @var string
+   */
+  protected $entityId;
+
+  /**
+   * Constructs a new PaymentGatewayPluginCollection object.
+   *
+   * @param \Drupal\Component\Plugin\PluginManagerInterface $manager
+   *   The manager to be used for instantiating plugins.
+   * @param string $instance_id
+   *   The ID of the plugin instance.
+   * @param array $configuration
+   *   An array of configuration.
+   * @param string $entity_id
+   *   The payment gateway entity ID this plugin collection belongs to.
+   */
+  public function __construct(PluginManagerInterface $manager, $instance_id, array $configuration, $entity_id) {
+    parent::__construct($manager, $instance_id, $configuration);
+
+    $this->entityId = $entity_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return \Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\PaymentGatewayInterface
+   */
+  public function &get($instance_id) {
+    return parent::get($instance_id);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function initializePlugin($instance_id) {
+    if (!$instance_id) {
+      throw new PluginException("The payment gateway '{$this->entityId}' did not specify a plugin.");
+    }
+
+    parent::initializePlugin($instance_id);
+  }
+
+}

--- a/modules/payment/src/PaymentMethodTypeManager.php
+++ b/modules/payment/src/PaymentMethodTypeManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\commerce_payment;
+
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Manages discovery and instantiation of payment method type plugins.
+ *
+ * @see \Drupal\commerce_payment\Annotation\CommercePaymentMethodType
+ * @see plugin_api
+ */
+class PaymentMethodTypeManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a new PaymentMethodTypeManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/Commerce/PaymentMethodType', $namespaces, $module_handler, 'Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType\PaymentMethodTypeInterface', 'Drupal\commerce_payment\Annotation\CommercePaymentMethodType');
+
+    $this->alterInfo('commerce_payment_method_type_info');
+    $this->setCacheBackend($cache_backend, 'commerce_payment_method_type_plugins');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processDefinition(&$definition, $plugin_id) {
+    parent::processDefinition($definition, $plugin_id);
+
+    foreach (['id', 'label', 'create_label'] as $required_property) {
+      if (empty($definition[$required_property])) {
+        throw new PluginException(sprintf('The payment method type %s must define the %s property.', $plugin_id, $required_property));
+      }
+    }
+  }
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/OnsitePaymentGatewayBase.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/OnsitePaymentGatewayBase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentGateway;
+
+use Drupal\commerce_payment\PaymentTypeManager;
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides the base class for onsite payment gateways.
+ */
+abstract class OnsitePaymentGatewayBase extends PaymentGatewayBase {
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/OnsitePaymentGatewayInterface.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/OnsitePaymentGatewayInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentGateway;
+
+/**
+ * Defines the base interface for onsite payment gateways.
+ */
+interface OnsitePaymentGatewayInterface extends PaymentGatewayInterface, SupportsStoredPaymentMethods {
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/PaymentGatewayBase.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/PaymentGatewayBase.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentGateway;
+
+use Drupal\commerce_payment\PaymentMethodTypeManager;
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides the base class for payment gateways.
+ */
+abstract class PaymentGatewayBase extends PluginBase implements PaymentGatewayInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The payment method types handled by the gateway.
+   *
+   * @var \Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType\PaymentMethodTypeInterface[]
+   */
+  protected $paymentMethodTypes;
+
+  /**
+   * Constructs a new PaymentGatewayBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\commerce_payment\PaymentMethodTypeManager $payment_method_type_manager
+   *   The payment method type manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PaymentMethodTypeManager $payment_method_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->entityTypeManager = $entity_type_manager;
+    // Instantiate the payment method types right away to ensure that
+    // their IDs are valid.
+    foreach ($this->pluginDefinition['payment_method_types'] as $plugin_id) {
+      $this->paymentMethodTypes[$plugin_id] = $payment_method_type_manager->createInstance($plugin_id);
+    }
+    $this->setConfiguration($configuration);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('plugin.manager.commerce_payment_method_type')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLabel() {
+    return $this->pluginDefinition['label'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDisplayLabel() {
+    return $this->configuration['display_label'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentMethodTypes() {
+    // Filter out payment method types disabled by the merchant.
+    return array_intersect_key($this->paymentMethodTypes, array_flip($this->configuration['payment_method_types']));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getWorkflowId() {
+    return $this->pluginDefinition['workflow'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMode() {
+    return $this->configuration['mode'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSupportedModes() {
+    return $this->pluginDefinition['modes'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfiguration() {
+    return $this->configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setConfiguration(array $configuration) {
+    $this->configuration = NestedArray::mergeDeep($this->defaultConfiguration(), $configuration);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    $modes = array_keys($this->getSupportedModes());
+
+    return [
+      'mode' => $modes ? reset($modes) : '',
+      'payment_method_types' => [],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $modes = $this->getSupportedModes();
+    $payment_method_types = array_map(function($payment_method_type) {
+      return $payment_method_type->getLabel();
+    }, $this->paymentMethodTypes);
+
+    $form['mode'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Mode'),
+      '#options' => $modes,
+      '#default_value' => $this->configuration['mode'],
+      '#required' => TRUE,
+      '#access' => !empty($modes),
+    ];
+    $form['payment_method_types'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Payment method types'),
+      '#options' => $payment_method_types,
+      '#default_value' => $this->configuration['payment_method_types'],
+      '#required' => TRUE,
+      '#access' => count($payment_method_types) > 1,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    if (!$form_state->getErrors()) {
+      $values = $form_state->getValue($form['#parents']);
+      $values['payment_method_types'] = array_filter($values['payment_method_types']);
+
+      $this->configuration['mode'] = $values['mode'];
+      $this->configuration['payment_method_types'] = array_keys($values['payment_method_types']);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildPaymentFieldDefinitions() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getForm($form_id) {
+    $forms = $this->pluginDefinition['forms'];
+    if (empty($forms[$form_id])) {
+      throw new \InvalidArgumentException(sprintf('Invalid form "%s" requested for plugin "%s"', $form_id, $this->getPluginId()));
+    }
+
+    return new $forms[$form_id]($this);
+  }
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/PaymentGatewayInterface.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/PaymentGatewayInterface.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentGateway;
+
+use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\DerivativeInspectionInterface;
+use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
+
+/**
+ * Defines the base interface for payment gateways.
+ */
+interface PaymentGatewayInterface extends ConfigurablePluginInterface, PluginFormInterface, PluginInspectionInterface, DerivativeInspectionInterface {
+
+  /**
+   * Gets the payment gateway label.
+   *
+   * The label is admin-facing and usually includes the name of the used API.
+   * For example: "Braintree (Hosted Fields)".
+   *
+   * @return mixed
+   */
+  public function getLabel();
+
+  /**
+   * Gets the payment gateway display label.
+   *
+   * The display label is customer-facing and more generic.
+   * For example: "Braintree".
+   *
+   * @return string
+   *   The payment gateway display label.
+   */
+  public function getDisplayLabel();
+
+  /**
+   * Gets the mode in which the payment gateway is operating.
+   *
+   * @return string
+   *   The machine name of the mode.
+   */
+  public function getMode();
+
+  /**
+   * Gets the supported modes.
+   *
+   * @return string[]
+   *   The mode labels keyed by machine name.
+   */
+  public function getSupportedModes();
+
+  /**
+   * Gets the payment method types handled by the payment gateway.
+   *
+   * @return \Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType\PaymentMethodTypeInterface[]
+   */
+  public function getPaymentMethodTypes();
+
+  /**
+   * Gets the payment workflow ID.
+   *
+   * @return string
+   *   The payment workflow ID.
+   */
+  public function getWorkflowId();
+
+  /**
+   * Gets the plugin form with the given ID.
+   *
+   * @param string $form_id
+   *   The form ID.
+   *
+   * @return \Drupal\commerce\Plugin\PluginFormInterface
+   */
+  public function getForm($form_id);
+
+  /**
+   * Builds the field definitions for the payment gateway's payments.
+   *
+   * Important:
+   * Field names must be unique across payment gateways.
+   * It is recommended to prefix them with the plugin ID.
+   *
+   * @return \Drupal\commerce\BundleFieldDefinition[]
+   *   An array of bundle field definitions, keyed by field name.
+   */
+  public function buildPaymentFieldDefinitions();
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsAuthorizations.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsAuthorizations.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentGateway;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_payment\Entity\PaymentInterface;
+use Drupal\commerce_payment\Entity\PaymentMethodInterface;
+use Drupal\commerce_price\Price;
+
+/**
+ * Defines the interface for gateways which support authorizing payments.
+ */
+interface SupportsAuthorizations {
+
+  /**
+   * Creates and authorizes a payment with the given amount.
+   *
+   * @param \Drupal\commerce_price\Price $amount
+   *   The amount to authorize.
+   * @param \Drupal\commerce_payment\Entity\PaymentMethodInterface $payment_method
+   *   The payment method, if known.
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The parent order.
+   */
+  public function authorize(Price $amount, PaymentMethodInterface $payment_method = NULL, OrderInterface $order);
+
+  /**
+   * Captures the given payment.
+   *
+   * Only payments in the 'authorization' state can be captured.
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentInterface $payment
+   *   The payment to capture.
+   * @param \Drupal\commerce_price\Price $amount
+   *   The amount to capture. If NULL, defaults to the entire payment amount.
+   */
+  public function capture(PaymentInterface $payment, Price $amount = NULL);
+
+  /**
+   * Voids the given payment.
+   *
+   * Only payments in the 'authorization' state can be voided.
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentInterface $payment
+   *   The payment to void.
+   */
+  public function void(PaymentInterface $payment);
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsRefunds.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsRefunds.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentGateway;
+
+use Drupal\commerce_payment\Entity\PaymentInterface;
+use Drupal\commerce_price\Price;
+
+/**
+ * Defines the interface for gateways which support refunds.
+ */
+interface SupportsRefunds {
+
+  /**
+   * Refunds the given payment.
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentInterface $payment
+   *   The payment to refund.
+   * @param \Drupal\commerce_price\Price $amount
+   *   The amount to refund. If NULL, defaults to the entire payment amount.
+   */
+  public function refund(PaymentInterface $payment, Price $amount = NULL);
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsStoredPaymentMethods.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsStoredPaymentMethods.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentGateway;
+
+use Drupal\commerce_payment\Entity\PaymentMethodInterface;
+
+/**
+ * Defines the interface for gateways which support storing payment methods.
+ */
+interface SupportsStoredPaymentMethods {
+
+  /**
+   * Creates a payment method with the given payment details.
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentMethodInterface $payment_method
+   *   The payment method.
+   * @param array $payment_details
+   *   The gateway-specific payment details.
+   */
+  public function createPaymentMethod(PaymentMethodInterface $payment_method, array $payment_details);
+
+  /**
+   * Deletes the given payment method.
+   *
+   * Both the entity and the remote record are deleted.
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentMethodInterface $payment_method
+   *   The payment method.
+   */
+  public function deletePaymentMethod(PaymentMethodInterface $payment_method);
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsUpdatingStoredPaymentMethods.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsUpdatingStoredPaymentMethods.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentGateway;
+
+use Drupal\commerce_payment\Entity\PaymentMethodInterface;
+
+/**
+ * Defines the interface for gateways which support updating stored payment methods.
+ */
+interface SupportsUpdatingStoredPaymentMethods {
+
+  /**
+   * Updates the given payment.
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentMethodInterface $payment_method
+   *   The payment method.
+   */
+  public function updatePaymentMethod(PaymentMethodInterface $payment_method);
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentMethodType/CreditCard.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentMethodType/CreditCard.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType;
+
+use Drupal\commerce\BundleFieldDefinition;
+use Drupal\commerce_payment\CreditCard as CreditCardHelper;
+use Drupal\commerce_payment\Entity\PaymentMethodInterface;
+
+/**
+ * Provides the credit card payment method type.
+ *
+ * @CommercePaymentMethodType(
+ *   id = "credit_card",
+ *   label = @Translation("Credit card"),
+ *   create_label = @Translation("New credit card"),
+ * )
+ */
+class CreditCard extends PaymentMethodTypeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildLabel(PaymentMethodInterface $payment_method) {
+    $card_type = CreditCardHelper::getType($payment_method->card_type->value);
+    $args = [
+      '@card_type' => $card_type->getLabel(),
+      '@card_number' => $payment_method->card_number->value,
+    ];
+    return $this->t('@card_type ending in @card_number', $args);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildFieldDefinitions() {
+    $fields = parent::buildFieldDefinitions();
+
+    $fields['card_type'] = BundleFieldDefinition::create('list_string')
+      ->setLabel(t('Card type'))
+      ->setDescription(t('The credit card type.'))
+      ->setRequired(TRUE)
+      ->setSetting('allowed_values_function', ['\Drupal\commerce_payment\CreditCard', 'getTypeLabels']);
+
+    $fields['card_number'] = BundleFieldDefinition::create('string')
+      ->setLabel(t('Card number'))
+      ->setDescription(t('The last 4 digits of the credit card number'))
+      ->setRequired(TRUE);
+
+    $fields['card_exp_month'] = BundleFieldDefinition::create('integer')
+      ->setLabel(t('Card expiration month'))
+      ->setDescription(t('The credit card expiration month.'))
+      ->setRequired(TRUE)
+      ->setSetting('size', 'tiny');
+
+    $fields['card_exp_year'] = BundleFieldDefinition::create('integer')
+      ->setLabel(t('Card expiration year'))
+      ->setDescription(t('The credit card expiration year.'))
+      ->setRequired(TRUE)
+      ->setSetting('size', 'tiny');
+
+    return $fields;
+  }
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentMethodType/PayPal.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentMethodType/PayPal.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType;
+
+use Drupal\commerce\BundleFieldDefinition;
+use Drupal\commerce_payment\Entity\PaymentMethodInterface;
+
+/**
+ * Provides the PayPal payment method type.
+ *
+ * @CommercePaymentMethodType(
+ *   id = "paypal",
+ *   label = @Translation("PayPal account"),
+ *   create_label = @Translation("New PayPal account"),
+ * )
+ */
+class PayPal extends PaymentMethodTypeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildLabel(PaymentMethodInterface $payment_method) {
+    $args = [
+      '@paypal_mail' => $payment_method->paypal_mail->value
+    ];
+    return $this->t('PayPal account (@paypal_mail)', $args);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildFieldDefinitions() {
+    $fields = parent::buildFieldDefinitions();
+
+    $fields['paypal_mail'] = BundleFieldDefinition::create('email')
+      ->setLabel(t('PayPal Email'))
+      ->setDescription(t('The email address associated with the PayPal account.'))
+      ->setRequired(TRUE);
+
+    return $fields;
+  }
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentMethodType/PaymentMethodTypeBase.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentMethodType/PaymentMethodTypeBase.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType;
+
+use Drupal\Core\Plugin\PluginBase;
+
+/**
+ * Provides the base payment method type class.
+ */
+abstract class PaymentMethodTypeBase extends PluginBase implements PaymentMethodTypeInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLabel() {
+    return $this->pluginDefinition['label'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCreateLabel() {
+    return $this->pluginDefinition['create_label'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildFieldDefinitions() {
+    return [];
+  }
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentMethodType/PaymentMethodTypeInterface.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentMethodType/PaymentMethodTypeInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType;
+
+use Drupal\commerce_payment\Entity\PaymentMethodInterface;
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Defines the interface for payment method types.
+ */
+interface PaymentMethodTypeInterface extends PluginInspectionInterface {
+
+  /**
+   * Gets the payment method type label.
+   *
+   * @return string
+   *   The payment method type label.
+   */
+  public function getLabel();
+
+  /**
+   * Gets the payment method type create label.
+   *
+   * @return string
+   *   The payment method type create label.
+   */
+  public function getCreateLabel();
+
+  /**
+   * Builds a label for the given payment method.
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentMethodInterface $payment_method
+   *   The payment method.
+   *
+   * @return string
+   *   The label.
+   */
+  public function buildLabel(PaymentMethodInterface $payment_method);
+
+  /**
+   * Builds the field definitions for payment methods of this type.
+   *
+   * Important:
+   * Field names must be unique across all payment method types.
+   * It is recommended to prefix them with the plugin ID.
+   *
+   * @return \Drupal\commerce\BundleFieldDefinition[]
+   *   An array of bundle field definitions, keyed by field name.
+   */
+  public function buildFieldDefinitions();
+
+}

--- a/src/BundleFieldDefinition.php
+++ b/src/BundleFieldDefinition.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\commerce;
+
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Provides a field definition class for bundle fields.
+ *
+ * Core currently doesn't provide one, the hook_entity_bundle_field_info()
+ * example uses BaseFieldDefinition, which is wrong. Tracked in #2346347.
+ *
+ * Note that this class implements both FieldStorageDefinitionInterface and
+ * FieldStorageDefinitionInterface. This is a Commerce simplification for
+ * DX reasons, allowing code to return just the bundle definitions instead of
+ * having to return both storage definitions and bundle definitions.
+ */
+class BundleFieldDefinition extends BaseFieldDefinition {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isBaseField() {
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
Brings PaymentGateway bundle functionality into its own class.
Invokes `onBundleDelete` before the config entity is deleted, so that the plugin can be instantiated.
Fixes bugs with `hook_entity_bundle_delete` implementation and field api.
