### PR TITLE
Fix bug in handling of EntityType properties

### DIFF
--- a/commerce.module
+++ b/commerce.module
@@ -145,7 +145,7 @@ function commerce_get_bundle_plugin_entity_types() {
  */
 function commerce_entity_type_build(array &$entity_types) {
   foreach ($entity_types as $entity_type) {
-    if (!empty($entity_type->bundle_plugin_type)) {
+    if ($entity_type->get('bundle_plugin_type')) {
       $entity_type->setHandlerClass('bundle_plugin', 'Drupal\commerce\BundlePluginHandler');
     }
   }


### PR DESCRIPTION
Annotation properties that don't exist in `Drupal\Core\Entity\EntityType` are stored in the `additional` property, as the constructor calls `set()` for each one.

https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21EntityType.php/function/EntityType%3A%3Aset/8.2.x
