### PR TITLE
Issue 2782489: Fix return  in buildPaneForm().

### DIFF
--- a/modules/checkout/src/Plugin/Commerce/CheckoutPane/CompletionMessage.php
+++ b/modules/checkout/src/Plugin/Commerce/CheckoutPane/CompletionMessage.php
@@ -68,7 +68,7 @@ class CompletionMessage extends CheckoutPaneBase {
     $message = $this->configuration['message'];
     $message = str_replace('%order_number', $this->order->getOrderNumber(), $message);
 
-    $pane_form = [
+    $pane_form['message'] = [
       '#markup' => $message,
     ];
     return $pane_form;


### PR DESCRIPTION
Method Drupal\commerce_checkout\Plugin\Commerce\CheckoutPane\CompletionMessage:buildPaneForm
receives array $pane_form with some values ('#parents', '#access'...), but returns array with just one key-value pair ( '#markup' => 'text of message').
I think it's a bug, because we can't use method isVisible(), for example.
