### PR TITLE
Issue #2718835 by mglaman, skyredwang: Make ProductAttribute getValue sorted by weights

### DIFF
--- a/modules/product/src/Entity/ProductAttribute.php
+++ b/modules/product/src/Entity/ProductAttribute.php
@@ -77,7 +77,7 @@ class ProductAttribute extends ConfigEntityBundleBase implements ProductAttribut
    */
   public function getValues() {
     $storage = $this->entityTypeManager()->getStorage('commerce_product_attribute_value');
-    return $storage->loadByProperties(['attribute' => $this->id]);
+    return $storage->loadByAttribute($this->id());
   }
 
   /**

--- a/modules/product/src/Entity/ProductAttributeValue.php
+++ b/modules/product/src/Entity/ProductAttributeValue.php
@@ -22,7 +22,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *   bundle_label = @Translation("Product attribute"),
  *   handlers = {
  *     "event" = "Drupal\commerce_product\Event\ProductAttributeValueEvent",
- *     "storage" = "Drupal\commerce\CommerceContentEntityStorage",
+ *     "storage" = "Drupal\commerce_product\ProductAttributeValueStorage",
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "views_data" = "Drupal\views\EntityViewsData",
  *     "translation" = "Drupal\content_translation\ContentTranslationHandler"

--- a/modules/product/src/Form/ProductAttributeForm.php
+++ b/modules/product/src/Form/ProductAttributeForm.php
@@ -165,8 +165,20 @@ class ProductAttributeForm extends BundleEntityFormBase {
         ],
       ];
       // Used by SortArray::sortByWeightProperty to sort the rows.
-      if (isset($user_input['values'][$index]) && !$form_state->get('reset_alphabetical')) {
-        $value_form['#weight'] = $user_input['values'][$index]['weight'];
+      if (isset($user_input['values'][$index])) {
+        $input_weight = $user_input['values'][$index]['weight'];
+        // If the weights were just reset, reflect it in the user input.
+        if ($form_state->get('reset_alphabetical')) {
+          $input_weight = $default_weight;
+        }
+        // Make sure the weight is not out of bounds due to removals.
+        if ($user_input['values'][$index]['weight'] > $max_weight) {
+          $input_weight = $max_weight;
+        }
+        // Reflect the updated user input on the element.
+        $value_form['weight']['#value'] = $input_weight;
+
+        $value_form['#weight'] = $input_weight;
       }
       else {
         $value_form['#weight'] = $default_weight;

--- a/modules/product/src/ProductAttributeValueStorage.php
+++ b/modules/product/src/ProductAttributeValueStorage.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\commerce_product;
+
+use Drupal\commerce\CommerceContentEntityStorage;
+
+/**
+ * Defines the product attribute value storage.
+ */
+class ProductAttributeValueStorage extends CommerceContentEntityStorage implements ProductAttributeValueStorageInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadByAttribute($attribute_id) {
+    $entity_query = $this->getQuery();
+    $entity_query->condition('attribute', $attribute_id);
+    $entity_query->sort('weight');
+    $entity_query->sort('name');
+    $result = $entity_query->execute();
+    return $result ? $this->loadMultiple($result) : [];
+  }
+
+}

--- a/modules/product/src/ProductAttributeValueStorageInterface.php
+++ b/modules/product/src/ProductAttributeValueStorageInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\commerce_product;
+
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+
+/**
+ * Defines the interface for product attribute value storage.
+ */
+interface ProductAttributeValueStorageInterface extends ContentEntityStorageInterface {
+
+  /**
+   * Loads product attribute values for the given product attribute.
+   *
+   * @param string $attribute_id
+   *   The product attribute ID.
+   *
+   * @return \Drupal\commerce_product\Entity\ProductAttributeValueInterface[]
+   *   The product attribute values, indexed by id, ordered by weight.
+   */
+  public function loadByAttribute($attribute_id);
+
+}

--- a/modules/product/tests/src/Functional/ProductAttributeTranslationTest.php
+++ b/modules/product/tests/src/Functional/ProductAttributeTranslationTest.php
@@ -65,10 +65,12 @@ class ProductAttributeTranslationTest extends ProductBrowserTestBase {
     $red_value = $this->createEntity('commerce_product_attribute_value', [
       'attribute' => 'color',
       'name' => 'Red',
+      'weight' => 0,
     ]);
     $blue_value = $this->createEntity('commerce_product_attribute_value', [
       'attribute' => 'color',
       'name' => 'Blue',
+      'weight' => 1,
     ]);
     // Confirm that the value translation form is still missing.
     $this->drupalGet('admin/commerce/product-attributes/manage/color/translate/fr/add');

--- a/modules/product/tests/src/FunctionalJavascript/ProductAttributeJavascriptTest.php
+++ b/modules/product/tests/src/FunctionalJavascript/ProductAttributeJavascriptTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\commerce_product\FunctionalJavascript;
 
-use Drupal\commerce_product\Entity\ProductAttribute;
 use Drupal\Tests\commerce\FunctionalJavascript\JavascriptTestTrait;
 use Drupal\Tests\commerce_product\Functional\ProductBrowserTestBase;
 
@@ -28,7 +27,7 @@ class ProductAttributeJavascriptTest extends ProductBrowserTestBase {
    * Tests managing product attribute values.
    */
   public function testProductAttributeValues() {
-    $this->createEntity('commerce_product_attribute', [
+    $attribute = $this->createEntity('commerce_product_attribute', [
       'id' => 'color',
       'label' => 'Color',
     ]);
@@ -44,21 +43,16 @@ class ProductAttributeJavascriptTest extends ProductBrowserTestBase {
     $this->getSession()->getPage()->pressButton('Add value');
     $this->waitForAjaxToFinish();
     $this->getSession()->getPage()->fillField('values[3][entity][name][0][value]', 'Black');
-
     $this->getSession()->getPage()->pressButton('Save');
-
     $this->assertSession()->pageTextContains('Updated the Color product attribute.');
 
-    $attribute = ProductAttribute::load('color');
-    $attribute_values = [];
-    /** @var \Drupal\commerce_product\Entity\ProductAttributeValueInterface $value */
-    foreach ($attribute->getValues() as $value) {
-      $attribute_values[] = $value->label();
-    }
-    $this->assertTrue($attribute_values[0] == 'Cyan');
-    $this->assertTrue($attribute_values[1] == 'Yellow');
-    $this->assertTrue($attribute_values[2] == 'Magenta');
-    $this->assertTrue($attribute_values[3] == 'Black');
+    // Assert order by weights.
+    \Drupal::entityTypeManager()->getStorage('commerce_product_attribute_value')->resetCache();
+    $attribute_values = array_values($attribute->getValues());
+    $this->assertEquals('Cyan', $attribute_values[0]->label());
+    $this->assertEquals('Yellow', $attribute_values[1]->label());
+    $this->assertEquals('Magenta', $attribute_values[2]->label());
+    $this->assertEquals('Black', $attribute_values[3]->label());
 
     $this->drupalGet('admin/commerce/product-attributes/manage/color');
     $this->getSession()->getPage()->pressButton('remove_value1');
@@ -69,26 +63,28 @@ class ProductAttributeJavascriptTest extends ProductBrowserTestBase {
     $this->waitForAjaxToFinish();
     $this->getSession()->getPage()->fillField('values[3][entity][name][0][value]', 'Cornflower Blue');
     $this->getSession()->getPage()->pressButton('Save');
-
     $this->assertSession()->pageTextContains('Updated the Color product attribute.');
 
-    $attribute = ProductAttribute::load('color');
-    $attribute_values = [];
-    /** @var \Drupal\commerce_product\Entity\ProductAttributeValueInterface $value */
-    foreach ($attribute->getValues() as $value) {
-      $attribute_values[] = $value->label();
-    }
-    $this->assertTrue($attribute_values[0] == 'Cyan');
-    $this->assertTrue($attribute_values[1] == 'Magenta');
-    $this->assertTrue($attribute_values[2] == 'Cornflower Blue');
+    // Assert order by weights.
+    \Drupal::entityTypeManager()->getStorage('commerce_product_attribute_value')->resetCache();
+    $attribute_values = array_values($attribute->getValues());
+    $this->assertEquals('Cyan', $attribute_values[0]->label());
+    $this->assertEquals('Magenta', $attribute_values[1]->label());
+    $this->assertEquals('Cornflower Blue', $attribute_values[2]->label());
 
     $this->drupalGet('admin/commerce/product-attributes/manage/color');
     $this->getSession()->getPage()->pressButton('Reset to alphabetical');
     $this->waitForAjaxToFinish();
     $this->getSession()->getPage()->pressButton('Save');
 
+    // Assert order by weights.
+    \Drupal::entityTypeManager()->getStorage('commerce_product_attribute_value')->resetCache();
+    $attribute_values = array_values($attribute->getValues());
+    $this->assertEquals('Cornflower Blue', $attribute_values[0]->label());
+    $this->assertEquals('Cyan', $attribute_values[1]->label());
+    $this->assertEquals('Magenta', $attribute_values[2]->label());
+
     $this->assertSession()->pageTextContains('Updated the Color product attribute.');
-    // @todo Confirm weights once $attribute->getValues() starts using them.
   }
 
 }

--- a/modules/product/tests/src/Kernel/ProductAttributeValueStorageTest.php
+++ b/modules/product/tests/src/Kernel/ProductAttributeValueStorageTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\Tests\commerce_product\Kernel;
+
+use Drupal\commerce_product\Entity\ProductAttribute;
+use Drupal\commerce_product\Entity\ProductAttributeValue;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+
+/**
+ * Tests the product attribute value storage.
+ *
+ * @group commerce
+ */
+class ProductAttributeValueStorageTest extends EntityKernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['system', 'field', 'options', 'user', 'path',
+    'text', 'entity', 'filter', 'entity_test', 'commerce', 'commerce_price',
+    'commerce_store', 'commerce_product', 'views', 'address', 'inline_entity_form',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('commerce_product_attribute');
+    $this->installEntitySchema('commerce_product_attribute_value');
+  }
+
+  /**
+   * Tests loadByAttribute()
+   */
+  public function testLoadByAttribute() {
+    $color_attribute = ProductAttribute::create([
+      'id' => 'color',
+      'label' => 'Color',
+    ]);
+    $color_attribute->save();
+
+    ProductAttributeValue::create([
+      'attribute' => 'color',
+      'name' => 'Black',
+      'weight' => 3,
+    ])->save();
+    ProductAttributeValue::create([
+      'attribute' => 'color',
+      'name' => 'Yellow',
+      'weight' => 2,
+    ])->save();
+    ProductAttributeValue::create([
+      'attribute' => 'color',
+      'name' => 'Magenta',
+      'weight' => 1,
+    ])->save();
+    ProductAttributeValue::create([
+      'attribute' => 'color',
+      'name' => 'Cyan',
+      'weight' => 0,
+    ])->save();
+
+    /** @var \Drupal\commerce_product\ProductAttributeValueStorageInterface $attribute_value_storage */
+    $attribute_value_storage = \Drupal::service('entity_type.manager')->getStorage('commerce_product_attribute_value');
+    /** @var \Drupal\commerce_product\Entity\ProductAttributeValueInterface[] $attribute_values */
+    $attribute_values = $attribute_value_storage->loadByAttribute('color');
+
+    $value = array_shift($attribute_values);
+    $this->assertEquals('Cyan', $value->getName());
+    $value = array_shift($attribute_values);
+    $this->assertEquals('Magenta', $value->getName());
+    $value = array_shift($attribute_values);
+    $this->assertEquals('Yellow', $value->getName());
+    $value = array_shift($attribute_values);
+    $this->assertEquals('Black', $value->getName());
+  }
+
+}


### PR DESCRIPTION
Continuation of #402.

Fixed the CS errors and this:

```
   public function getValues() {
     $storage = $this->entityTypeManager()->getStorage('commerce_product_attribute_value');
-    return $storage->loadByAttribute(['attribute' => $this->id]);
+    return $storage->loadByAttribute($this->id());
   }
```

Rewrote the #value fix in ProductAttributeForm to be more clean.
