### PR TITLE
Make it possible to add a line item to cart that doesn't have a product

### DIFF
--- a/modules/cart/src/Event/CartEntityAddEvent.php
+++ b/modules/cart/src/Event/CartEntityAddEvent.php
@@ -47,14 +47,14 @@ class CartEntityAddEvent extends Event {
    *
    * @param \Drupal\commerce_order\Entity\OrderInterface $cart
    *   The cart order.
-   * @param \Drupal\commerce\PurchasableEntityInterface $entity
+   * @param \Drupal\commerce\PurchasableEntityInterface|NULL $entity
    *   The added entity.
    * @param float $quantity
    *   The quantity.
    * @param \Drupal\commerce_order\Entity\LineItemInterface $line_item
    *   The destination line item.
    */
-  public function __construct(OrderInterface $cart, PurchasableEntityInterface $entity, $quantity, LineItemInterface $line_item) {
+  public function __construct(OrderInterface $cart, PurchasableEntityInterface $entity = NULL, $quantity, LineItemInterface $line_item) {
     $this->cart = $cart;
     $this->entity = $entity;
     $this->quantity = $quantity;
@@ -78,7 +78,7 @@ class CartEntityAddEvent extends Event {
    *   The added entity.
    */
   public function getEntity() {
-    return $this->cart;
+    return $this->entity;
   }
 
   /**


### PR DESCRIPTION
This add flexibility, since the line item doesn't require a PurchasableEntityInterface to be set on the line item, the Event for adding it to cart shouldn't require it as well.

Fix getEntity method on CartEntityAddEvent
