### PR TITLE
Fix value used in createPaymentMethod must be array

### DIFF
--- a/modules/payment/src/PluginForm/PaymentMethodAddForm.php
+++ b/modules/payment/src/PluginForm/PaymentMethodAddForm.php
@@ -85,7 +85,7 @@ class PaymentMethodAddForm extends PaymentGatewayFormBase {
     // The payment method form is customer facing. For security reasons
     // the returned errors need to be more generic.
     try {
-      $payment_gateway_plugin->createPaymentMethod($payment_method, $values['payment_details']);
+      $payment_gateway_plugin->createPaymentMethod($payment_method, $values);
     }
     catch (DeclineException $e) {
       \Drupal::logger('commerce_payment')->warning($e->getMessage());


### PR DESCRIPTION
$values is $values['payment_details'] with latest stable core. The effect is a notice and sending NULL to createPaymentMethod which can lead to fatal depending on PHP config/version since it must be an array.
