### PR TITLE
Order payment method should be selectable and default

### DIFF
--- a/modules/payment/src/Plugin/Commerce/CheckoutPane/PaymentInformation.php
+++ b/modules/payment/src/Plugin/Commerce/CheckoutPane/PaymentInformation.php
@@ -124,6 +124,10 @@ class PaymentInformation extends CheckoutPaneBase implements ContainerFactoryPlu
     $options = [];
     $default_option = NULL;
     $owner = $this->order->getOwner();
+    $current_payment_method = $this->order->payment_method->entity;
+    if ($current_payment_method) {
+      $options[$current_payment_method->id()] = $current_payment_method->label();
+    }
     if ($owner) {
       $payment_methods = $payment_method_storage->loadReusable($owner, $payment_gateway);
       foreach ($payment_methods as $payment_method) {
@@ -139,6 +143,9 @@ class PaymentInformation extends CheckoutPaneBase implements ContainerFactoryPlu
     $values = $form_state->getValue($pane_form['#parents']);
     if (!empty($values['payment_method'])) {
       $selected_option = $values['payment_method'];
+    }
+    elseif (!empty($current_payment_method)) {
+      $selected_option = $current_payment_method->id();
     }
     else {
       // @todo Use the default payment method instead.


### PR DESCRIPTION
Right now, if a user has saved a payment method on an order (not reusable) and somehow comes back to the payment information pane (maybe he decided to buy some more stuff or something), he will be prompted to create a new payment method (or use an existing reusable).

The payment method actually used on an order should take precedence over existing reusable ones and always be default.
