### PR TITLE
Provide UI help text for Commerce configuration types

### DIFF
--- a/modules/checkout/commerce_checkout.module
+++ b/modules/checkout/commerce_checkout.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Implements hook_theme().
@@ -29,6 +30,20 @@ function commerce_checkout_theme() {
   ];
 
   return $theme;
+}
+
+/**
+ * Implements hook_help().
+ */
+function commerce_checkout_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'entity.commerce_checkout_flow.collection':
+      $output = '<p>' . t('Checkout flows are used by <a href=":order_types">order types</a> to determine the order and appearance of checkout panes including payment, contact, and shipping information.', [
+        ':order_types' => \Drupal::url('entity.commerce_order_type.collection')
+        ]) . '</p>';
+      return $output;
+      break;
+  }
 }
 
 /**

--- a/modules/order/commerce_order.module
+++ b/modules/order/commerce_order.module
@@ -8,8 +8,30 @@
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Implements hook_help().
+ */
+function commerce_order_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'entity.commerce_order_type.collection':
+      $output = '<p>' . t('Order types are configurations of shopping cart, workflow and checkout settings for customizing the experience of ordering different types of products. For example, physical products, digital products and event registrations may each have different ordering experiences by configuring their <a href=":line_item_types">line item types</a> to use one of these order types.', [
+          ':line_item_types' => \Drupal::url('entity.commerce_line_item_type.collection')
+        ]) . '</p>';
+      return $output;
+      break;
+    case 'entity.commerce_line_item_type.collection':
+      $output = '<p>' . t('Line item types determine the <a href=":order_types">order type</a>, purchasable entity and the configuration of the add to cart form for each of the <a href=":variation_types">product variation types</a>.', [
+          ':variation_types' => \Drupal::url('entity.commerce_product_variation_type.collection'),
+          ':order_types' => \Drupal::url('entity.commerce_order_type.collection'),
+        ]) . '</p>';
+      return $output;
+      break;
+  }
+}
 
 /**
  * Implements hook_theme().

--- a/modules/product/commerce_product.module
+++ b/modules/product/commerce_product.module
@@ -14,7 +14,28 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Render\Element;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\commerce_product\Entity\ProductType;
+
+/**
+ * Implements hook_help().
+ */
+function commerce_product_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'entity.commerce_product_type.collection':
+      $output = '<p>' . t('Select the <a href=":variation_types">product variation type</a> and configure the entity fields, forms and displays for each type of product in your store.', [
+          ':variation_types' => \Drupal::url('entity.commerce_product_variation_type.collection')
+        ]) . '</p>';
+      return $output;
+      break;
+    case 'entity.commerce_product_variation_type.collection':
+      $output = '<p>' . t('Product variation types determine the <a href=":line_item_types">line item type</a> and attributes for each type of product variation.', [
+          ':line_item_types' => \Drupal::url('entity.commerce_line_item_type.collection')
+        ]) . '</p>';
+      return $output;
+      break;
+  }
+}
 
 /**
  * Implements hook_config_translation_info_alter().

--- a/modules/store/commerce_store.module
+++ b/modules/store/commerce_store.module
@@ -7,6 +7,21 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function commerce_store_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'entity.commerce_store_type.collection':
+      $output = '<p>' . t('Store types allow <a href=":stores">stores</a> to be created for different locations or by individual sellers. Configure the entity fields, forms and displays for each type of store on your site.', [
+          ':stores' => \Drupal::url('entity.commerce_store.collection')
+        ]) . '</p>';
+      return $output;
+      break;
+  }
+}
 
 /**
  * Implements hook_theme().


### PR DESCRIPTION
 Adds hook_help() implementations for checkout, order, product and store entity collection pages.
