### PR TITLE
#2805625: Add a new service to manage the product variation rendering

### DIFF
--- a/modules/product/commerce_product.module
+++ b/modules/product/commerce_product.module
@@ -84,30 +84,6 @@ function commerce_product_theme() {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_view().
- */
-function commerce_product_commerce_product_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-  /** @var \Drupal\commerce_product\Entity\ProductInterface $entity */
-  $product_type = ProductType::load($entity->bundle());
-  if ($product_type->shouldInjectVariationFields() && $entity->getDefaultVariation()) {
-    /** @var \Drupal\commerce_product\ProductVariationFieldRendererInterface $variation_field_renderer */
-    $variation_field_renderer = \Drupal::service('commerce_product.variation_field_renderer');
-
-    $variation = \Drupal::entityTypeManager()->getStorage('commerce_product_variation')->loadFromContext($entity);
-    $rendered_fields = $variation_field_renderer->renderFields($variation, $view_mode);
-    foreach ($rendered_fields as $field_name => $rendered_field) {
-      // Group attribute fields to allow them to be excluded together.
-      if (strpos($field_name, 'attribute_') !== FALSE) {
-        $build['variation_attributes']['variation_' . $field_name] = $rendered_field;
-      }
-      else {
-        $build['variation_' . $field_name] = $rendered_field;
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_theme_suggestions_commerce_product().
  */
 function commerce_product_theme_suggestions_commerce_product(array $variables) {

--- a/modules/product/src/Entity/Product.php
+++ b/modules/product/src/Entity/Product.php
@@ -27,7 +27,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *     "storage" = "Drupal\commerce\CommerceContentEntityStorage",
  *     "access" = "\Drupal\commerce\EntityAccessControlHandler",
  *     "permission_provider" = "\Drupal\commerce\EntityPermissionProvider",
- *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "view_builder" = "Drupal\commerce_product\ProductViewBuilder",
  *     "list_builder" = "Drupal\commerce_product\ProductListBuilder",
  *     "views_data" = "Drupal\views\EntityViewsData",
  *     "form" = {

--- a/modules/product/src/ProductViewBuilder.php
+++ b/modules/product/src/ProductViewBuilder.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\commerce_product;
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityViewBuilder;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines the entity view builder for products.
+ */
+class ProductViewBuilder extends EntityViewBuilder {
+
+  /**
+   * The product field variation renderer.
+   *
+   * @var \Drupal\commerce_product\ProductVariationFieldRenderer
+   */
+  protected $productVariationFieldRenderer;
+
+  /**
+   * Constructs a new ProductViewBuilder.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   *   The entity manager service.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   * @param \Drupal\commerce_product\ProductVariationFieldRenderer $product_variation_field_renderer
+   *   The product variation field renderer.
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityManagerInterface $entity_manager, LanguageManagerInterface $language_manager, ProductVariationFieldRenderer $product_variation_field_renderer) {
+    parent::__construct($entity_type, $entity_manager, $language_manager);
+    $this->productVariationFieldRenderer = $product_variation_field_renderer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type,
+      $container->get('entity.manager'),
+      $container->get('language_manager'),
+      $container->get('commerce_product.variation_field_renderer')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterBuild(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+    $product_type_storage = $this->entityManager->getStorage('commerce_product_type');
+    $variation_storage = $this->entityManager->getStorage('commerce_product_variation');
+
+    /** @var \Drupal\commerce_product\Entity\ProductTypeInterface $product_type */
+    $product_type = $product_type_storage->load($entity->bundle());
+    if ($product_type->shouldInjectVariationFields() && $entity->getDefaultVariation()) {
+      $variation = $variation_storage->loadFromContext($entity);
+      $rendered_fields = $this->productVariationFieldRenderer->renderFields($variation, $view_mode);
+      foreach ($rendered_fields as $field_name => $rendered_field) {
+        // Group attribute fields to allow them to be excluded together.
+        if (strpos($field_name, 'attribute_') !== FALSE) {
+          $build['variation_attributes']['variation_' . $field_name] = $rendered_field;
+        }
+        else {
+          $build['variation_' . $field_name] = $rendered_field;
+        }
+      }
+    }
+  }
+
+}

--- a/modules/product/src/ProductViewBuilder.php
+++ b/modules/product/src/ProductViewBuilder.php
@@ -20,10 +20,10 @@ class ProductViewBuilder extends EntityViewBuilder {
    *
    * @var \Drupal\commerce_product\ProductVariationFieldRenderer
    */
-  protected $productVariationFieldRenderer;
+  protected $variationFieldRenderer;
 
   /**
-   * Constructs a new ProductViewBuilder.
+   * Constructs a new ProductViewBuilder object.
    *
    * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
    *   The entity type definition.
@@ -31,12 +31,12 @@ class ProductViewBuilder extends EntityViewBuilder {
    *   The entity manager service.
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    *   The language manager.
-   * @param \Drupal\commerce_product\ProductVariationFieldRenderer $product_variation_field_renderer
+   * @param \Drupal\commerce_product\ProductVariationFieldRenderer $variation_field_renderer
    *   The product variation field renderer.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityManagerInterface $entity_manager, LanguageManagerInterface $language_manager, ProductVariationFieldRenderer $product_variation_field_renderer) {
+  public function __construct(EntityTypeInterface $entity_type, EntityManagerInterface $entity_manager, LanguageManagerInterface $language_manager, ProductVariationFieldRenderer $variation_field_renderer) {
     parent::__construct($entity_type, $entity_manager, $language_manager);
-    $this->productVariationFieldRenderer = $product_variation_field_renderer;
+    $this->variationFieldRenderer = $variation_field_renderer;
   }
 
   /**
@@ -62,7 +62,7 @@ class ProductViewBuilder extends EntityViewBuilder {
     $product_type = $product_type_storage->load($entity->bundle());
     if ($product_type->shouldInjectVariationFields() && $entity->getDefaultVariation()) {
       $variation = $variation_storage->loadFromContext($entity);
-      $rendered_fields = $this->productVariationFieldRenderer->renderFields($variation, $view_mode);
+      $rendered_fields = $this->variationFieldRenderer->renderFields($variation, $view_mode);
       foreach ($rendered_fields as $field_name => $rendered_field) {
         // Group attribute fields to allow them to be excluded together.
         if (strpos($field_name, 'attribute_') !== FALSE) {


### PR DESCRIPTION
**Problem/Motivation**

Currently, the product variation fields are added to the Product render array in commerce_product_commerce_product_view() function.

When someone needs to rewrite that logic, it's necessary to implement that hook, or the _alter() version to override that behavior. That also forces to redo that logic again, hitting performance.

That's why we think a good improvement would be to add a service where that task in performed. In this way, this logic can be replaced without need to redo all the processing when users need to rewrite the default behavior.

**Proposed resolution**

Add the concept of _ProductVariationRenderer_, as tagged service where implement the logic explained above
Create a _ProductVariationRendererManager_ service that takes care of managing the different Product Variation Renderers
Create a default service _ProductVariationRendererDefault_ that implements the code the currently is in commerce_product_commerce_product_view()

**API changes**

Add a new service to manage Product Variation rendering inside products
