### PR TITLE
Issue #2808813 by steveoliver: New user account should own previous guest checkout order(s)

### DIFF
--- a/modules/checkout/tests/src/Functional/CheckoutOrderTest.php
+++ b/modules/checkout/tests/src/Functional/CheckoutOrderTest.php
@@ -182,6 +182,18 @@ class CheckoutOrderTest extends CommerceBrowserTestBase {
   }
 
   /**
+   * Tests that a guest order is associated to a Drupal user created after checkout.
+   */
+  public function testAccountOrderAfterGuestCheckout() {
+    $this->testGuestOrderCheckout();
+    $order = Order::load(1);
+    $this->assertEmpty($order->getOwnerId(), 'Guest checkout order has no owner.');
+    $user = $this->createUser([], 'guest', FALSE);
+    $order = Order::load(1);
+    $this->assertEquals($user->id(), $order->getOwnerId(), 'Guest checkout order is owned by new guest user account.');
+  }
+
+  /**
    * Tests that you can register from the checkout pane.
    */
   public function testRegisterOrderCheckout() {

--- a/modules/checkout/tests/src/Functional/CheckoutOrderTest.php
+++ b/modules/checkout/tests/src/Functional/CheckoutOrderTest.php
@@ -182,18 +182,6 @@ class CheckoutOrderTest extends CommerceBrowserTestBase {
   }
 
   /**
-   * Tests that a guest order is associated to a Drupal user created after checkout.
-   */
-  public function testAccountOrderAfterGuestCheckout() {
-    $this->testGuestOrderCheckout();
-    $order = Order::load(1);
-    $this->assertEmpty($order->getOwnerId(), 'Guest checkout order has no owner.');
-    $user = $this->createUser([], 'guest', FALSE);
-    $order = Order::load(1);
-    $this->assertEquals($user->id(), $order->getOwnerId(), 'Guest checkout order is owned by new guest user account.');
-  }
-
-  /**
    * Tests that you can register from the checkout pane.
    */
   public function testRegisterOrderCheckout() {

--- a/modules/order/commerce_order.module
+++ b/modules/order/commerce_order.module
@@ -5,6 +5,7 @@
  * Defines the Order entity and associated features.
  */
 
+use Drupal\commerce_order\Entity\Order;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
@@ -35,6 +36,23 @@ function commerce_order_theme($existing, $type, $theme, $path) {
 function commerce_order_local_tasks_alter(&$definitions) {
   $id = 'entity.profile.user_profile_form:profile.type.customer';
   $definitions[$id]['title'] = t('Address book');
+}
+
+/**
+ * Implements hook_user_insert().
+ */
+function commerce_order_user_insert($account) {
+  // Assigns guest orders to account if they used the account's email address.
+  $order_ids = \Drupal::entityQuery('commerce_order')
+    ->condition('mail', $account->getEmail())
+    ->execute();
+  if ($order_ids) {
+    $orders = Order::loadMultiple($order_ids);
+    foreach ($orders as $order) {
+      $order->setOwnerId($account->id());
+      $order->save();
+    }
+  }
 }
 
 /**

--- a/modules/order/commerce_order.module
+++ b/modules/order/commerce_order.module
@@ -41,9 +41,10 @@ function commerce_order_local_tasks_alter(&$definitions) {
 
 /**
  * Implements hook_ENTITY_TYPE_insert() for user entities.
+ *
+ * - Assigns any previous guest orders to new user account.
  */
 function commerce_order_user_insert(AccountInterface $user) {
-  // Assigns guest orders to account if they used the account's email address.
   $order_ids = \Drupal::entityQuery('commerce_order')
     ->condition('mail', $user->getEmail())
     ->execute();

--- a/modules/order/commerce_order.module
+++ b/modules/order/commerce_order.module
@@ -9,6 +9,7 @@ use Drupal\commerce_order\Entity\Order;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 
@@ -39,17 +40,17 @@ function commerce_order_local_tasks_alter(&$definitions) {
 }
 
 /**
- * Implements hook_user_insert().
+ * Implements hook_ENTITY_TYPE_insert() for user entities.
  */
-function commerce_order_user_insert($account) {
+function commerce_order_user_insert(AccountInterface $user) {
   // Assigns guest orders to account if they used the account's email address.
   $order_ids = \Drupal::entityQuery('commerce_order')
-    ->condition('mail', $account->getEmail())
+    ->condition('mail', $user->getEmail())
     ->execute();
   if ($order_ids) {
     $orders = Order::loadMultiple($order_ids);
     foreach ($orders as $order) {
-      $order->setOwnerId($account->id());
+      $order->setOwnerId($user->id());
       $order->save();
     }
   }

--- a/modules/order/tests/src/Functional/OrderAccountTest.php
+++ b/modules/order/tests/src/Functional/OrderAccountTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\Tests\commerce_order\Functional;
+
+use Drupal\commerce_order\Entity\Order;
+
+/**
+ * Tests the order account (owner) functionality.
+ *
+ * @group commerce
+ */
+class OrderAccountTest extends OrderBrowserTestBase {
+
+  /**
+   * Tests assigning guest orders to newly created users (after checkout).
+   */
+  public function testNewAccountOwnsOrderAfterGuestCheckout() {
+    $order_item = $this->createEntity('commerce_order_item', [
+      'type' => 'product_variation',
+    ]);
+    $order = $this->createEntity('commerce_order', [
+      'type' => 'default',
+      'mail' => 'guest@example.com',
+      'order_items' => [$order_item],
+    ]);
+    $order = Order::load($order->id());
+
+    $this->assertEmpty($order->getOwnerId(), 'The guest order has no owner account.');
+    $user = $this->createUser([], 'guest');
+    $this->assertEquals($order->getOwnerId(), $user->id(), 'New user account owns previous guest order.');
+  }
+
+}

--- a/modules/order/tests/src/Functional/OrderAccountTest.php
+++ b/modules/order/tests/src/Functional/OrderAccountTest.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\Tests\commerce_order\Functional;
 
-use Drupal\commerce_order\Entity\Order;
-
 /**
  * Tests the order account (owner) functionality.
  *
@@ -20,14 +18,14 @@ class OrderAccountTest extends OrderBrowserTestBase {
     ]);
     $order = $this->createEntity('commerce_order', [
       'type' => 'default',
+      'uid' => 0,
       'mail' => 'guest@example.com',
       'order_items' => [$order_item],
     ]);
-    $order = Order::load($order->id());
-
-    $this->assertEquals(0, $order->getOwnerId(), 'The guest order has no owner account.');
+    $order->save();
+    $this->assertEmpty($order->getOwnerId(), 'The guest order has no owner account.');
     $user = $this->createUser([], 'guest');
-    $this->assertEquals($order->getOwnerId(), $user->id(), 'New user account owns previous guest order.');
+    $this->assertEquals($user->id(), $order->getOwnerId(), 'New user account owns previous guest order.');
   }
 
 }

--- a/modules/order/tests/src/Functional/OrderAccountTest.php
+++ b/modules/order/tests/src/Functional/OrderAccountTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\commerce_order\Functional;
 
+use Drupal\commerce_order\Entity\Order;
+
 /**
  * Tests the order account (owner) functionality.
  *
@@ -22,9 +24,9 @@ class OrderAccountTest extends OrderBrowserTestBase {
       'mail' => 'guest@example.com',
       'order_items' => [$order_item],
     ]);
-    $order->save();
     $this->assertEmpty($order->getOwnerId(), 'The guest order has no owner account.');
     $user = $this->createUser([], 'guest');
+    $order = Order::load($order->id());
     $this->assertEquals($user->id(), $order->getOwnerId(), 'New user account owns previous guest order.');
   }
 

--- a/modules/order/tests/src/Functional/OrderAccountTest.php
+++ b/modules/order/tests/src/Functional/OrderAccountTest.php
@@ -25,7 +25,7 @@ class OrderAccountTest extends OrderBrowserTestBase {
     ]);
     $order = Order::load($order->id());
 
-    $this->assertEmpty($order->getOwnerId(), 'The guest order has no owner account.');
+    $this->assertEquals(0, $order->getOwnerId(), 'The guest order has no owner account.');
     $user = $this->createUser([], 'guest');
     $this->assertEquals($order->getOwnerId(), $user->id(), 'New user account owns previous guest order.');
   }


### PR DESCRIPTION
First failing test for this feature.
