### PR TITLE
Issue #2813583 by mglaman, bojanz: Expand the order refresh logic

### DIFF
--- a/commerce.services.yml
+++ b/commerce.services.yml
@@ -46,6 +46,10 @@ services:
     class: Drupal\commerce\Config\ConfigUpdater
     arguments: ['@entity_type.manager', '@config.storage', '@config.factory']
 
+  commerce.time:
+    class: Drupal\commerce\Time
+    arguments: ['@request_stack']
+
   cache_context.country:
     class: Drupal\commerce\Cache\Context\CountryCacheContext
     arguments: ['@commerce.country_context']

--- a/modules/cart/src/CartManager.php
+++ b/modules/cart/src/CartManager.php
@@ -68,6 +68,7 @@ class CartManager implements CartManagerInterface {
       $order_item->delete();
     }
     $cart->setItems([]);
+    $cart->setAdjustments([]);
 
     $this->eventDispatcher->dispatch(CartEvents::CART_EMPTY, new CartEmptyEvent($cart, $order_items));
     if ($save_cart) {

--- a/modules/order/commerce_order.services.yml
+++ b/modules/order/commerce_order.services.yml
@@ -16,7 +16,7 @@ services:
 
   commerce_order.order_refresh:
     class: Drupal\commerce_order\OrderRefresh
-    arguments: ['@entity_type.manager', '@commerce_price.chain_price_resolver', '@current_user']
+    arguments: ['@entity_type.manager', '@commerce_price.chain_price_resolver', '@current_user', '@commerce.time']
     tags:
       - { name: service_collector, call: addProcessor, tag: commerce_order.order_processor }
 

--- a/modules/order/config/install/commerce_order.commerce_order_type.default.yml
+++ b/modules/order/config/install/commerce_order.commerce_order_type.default.yml
@@ -3,5 +3,5 @@ status: true
 label: Default
 id: default
 workflow: order_default
-refresh_mode: always
-refresh_frequency: 30
+refresh_mode: customer
+refresh_frequency: 300

--- a/modules/order/src/Entity/Order.php
+++ b/modules/order/src/Entity/Order.php
@@ -314,6 +314,24 @@ class Order extends ContentEntityBase implements OrderInterface {
   /**
    * {@inheritdoc}
    */
+  public function getRefreshState() {
+    $data = $this->getData();
+    return !empty($data['refresh_state']) ? $data['refresh_state'] : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRefreshState($refresh_state) {
+    $data = $this->getData();
+    $data['refresh_state'] = $refresh_state;
+    $this->setData($data);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getData() {
     $data = [];
     if (!$this->get('data')->isEmpty()) {
@@ -391,6 +409,10 @@ class Order extends ContentEntityBase implements OrderInterface {
       }
     }
 
+    // Refresh draft orders on every save.
+    if ($this->getState()->value == 'draft' && empty($this->getRefreshState())) {
+      $this->setRefreshState(self::REFRESH_ON_SAVE);
+    }
     $this->recalculateTotalPrice();
   }
 
@@ -458,6 +480,7 @@ class Order extends ContentEntityBase implements OrderInterface {
     // If no order number has been set explicitly, set it to the order ID.
     if (!$this->getOrderNumber()) {
       $this->setOrderNumber($this->id());
+      $this->setRefreshState(self::REFRESH_SKIP);
       $this->save();
     }
 

--- a/modules/order/src/Entity/OrderInterface.php
+++ b/modules/order/src/Entity/OrderInterface.php
@@ -14,6 +14,11 @@ use Drupal\user\UserInterface;
  */
 interface OrderInterface extends ContentEntityInterface, EntityAdjustableInterface, EntityChangedInterface {
 
+  // Refresh states.
+  const REFRESH_ON_LOAD = 'refresh_on_load';
+  const REFRESH_ON_SAVE = 'refresh_on_save';
+  const REFRESH_SKIP = 'refresh_skip';
+
   /**
    * Gets the order number.
    *
@@ -230,6 +235,27 @@ interface OrderInterface extends ContentEntityInterface, EntityAdjustableInterfa
    *   The order state.
    */
   public function getState();
+
+  /**
+   * Gets the order refresh state.
+   *
+   * @return string|null
+   *   The refresh state, if set. One of the following order constants:
+   *   REFRESH_ON_LOAD: The order should be refreshed when it is next loaded.
+   *   REFRESH_ON_SAVE: The order should be refreshed before it is saved.
+   *   REFRESH_SKIP: The order should not be refreshed for now.
+   */
+  public function getRefreshState();
+
+  /**
+   * Sets the order refresh state.
+   *
+   * @param string $refresh_state
+   *   The order refresh state.
+   *
+   * @return $this
+   */
+  public function setRefreshState($refresh_state);
 
   /**
    * Gets the order data.

--- a/modules/order/src/Entity/OrderType.php
+++ b/modules/order/src/Entity/OrderType.php
@@ -121,7 +121,8 @@ class OrderType extends ConfigEntityBundleBase implements OrderTypeInterface {
    * {@inheritdoc}
    */
   public function getRefreshFrequency() {
-    return $this->refresh_frequency;
+    // The refresh frequency must always be at least 1s.
+    return !empty($this->refresh_frequency) ? $this->refresh_frequency : 1;
   }
 
   /**

--- a/modules/order/src/Entity/OrderTypeInterface.php
+++ b/modules/order/src/Entity/OrderTypeInterface.php
@@ -9,6 +9,7 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
  */
 interface OrderTypeInterface extends ConfigEntityInterface {
 
+  // Refresh modes.
   const REFRESH_ALWAYS = 'always';
   const REFRESH_CUSTOMER = 'customer';
 

--- a/modules/order/src/Form/OrderTypeForm.php
+++ b/modules/order/src/Form/OrderTypeForm.php
@@ -56,9 +56,8 @@ class OrderTypeForm extends BundleEntityFormBase {
       '#collapsible' => TRUE,
       '#tree' => FALSE,
     ];
-
     $form['refresh']['refresh_intro'] = [
-      '#markup' => '<p>' . t('These settings let you control how draft orders are refreshed, the process during which order item prices are recalculated.') . '</p>',
+      '#markup' => '<p>' . t('These settings let you control how draft orders are refreshed, the process during which prices are recalculated.') . '</p>',
     ];
     $form['refresh']['refresh_mode'] = [
       '#type' => 'radios',
@@ -67,14 +66,15 @@ class OrderTypeForm extends BundleEntityFormBase {
         OrderType::REFRESH_ALWAYS => t('Refresh a draft order when it is loaded regardless of who it belongs to.'),
         OrderType::REFRESH_CUSTOMER => t('Only refresh a draft order when it is loaded if it belongs to the current user.'),
       ],
-      '#default_value' => ($order_type->isNew()) ? OrderType::REFRESH_ALWAYS : $order_type->getRefreshMode(),
+      '#default_value' => ($order_type->isNew()) ? OrderType::REFRESH_CUSTOMER : $order_type->getRefreshMode(),
     ];
     $form['refresh']['refresh_frequency'] = [
-      '#type' => 'textfield',
+      '#type' => 'number',
       '#title' => t('Order refresh frequency'),
       '#description' => t('Draft orders will only be refreshed if more than the specified number of seconds have passed since they were last refreshed.'),
-      '#default_value' => ($order_type->isNew()) ? 30 : $order_type->getRefreshFrequency(),
+      '#default_value' => ($order_type->isNew()) ? 300 : $order_type->getRefreshFrequency(),
       '#required' => TRUE,
+      '#min' => 1,
       '#size' => 10,
       '#field_suffix' => t('seconds'),
     ];

--- a/modules/order/src/OrderRefresh.php
+++ b/modules/order/src/OrderRefresh.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\commerce_order;
 
+use Drupal\commerce\TimeInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderType;
-use Drupal\commerce_price\Resolver\ChainPriceResolver;
 use Drupal\commerce_price\Resolver\ChainPriceResolverInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Session\AccountInterface;
 
 /**
  * Default implementation for order refresh.
@@ -36,13 +36,18 @@ class OrderRefresh implements OrderRefreshInterface {
   protected $currentUser;
 
   /**
+   * The time.
+   *
+   * @var \Drupal\commerce\TimeInterface
+   */
+  protected $time;
+
+  /**
    * The order processors.
    *
    * @var \Drupal\commerce_order\OrderProcessorInterface[]
    */
-  protected $processors;
-
-  protected static $refreshingOrders = [];
+  protected $processors = [];
 
   /**
    * Constructs a new OrderRefresh object.
@@ -51,13 +56,16 @@ class OrderRefresh implements OrderRefreshInterface {
    *   The entity type manager.
    * @param \Drupal\commerce_price\Resolver\ChainPriceResolverInterface $chain_price_resolver
    *   The chain price resolver.
-   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   * @param \Drupal\Core\Session\AccountInterface $current_user
    *   The current user.
+   * @param \Drupal\commerce\TimeInterface $time
+   *   The time.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, ChainPriceResolverInterface $chain_price_resolver, AccountProxyInterface $current_user) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ChainPriceResolverInterface $chain_price_resolver, AccountInterface $current_user, TimeInterface $time) {
     $this->orderTypeStorage = $entity_type_manager->getStorage('commerce_order_type');
     $this->chainPriceResolver = $chain_price_resolver;
     $this->currentUser = $current_user;
+    $this->time = $time;
   }
 
   /**
@@ -70,22 +78,13 @@ class OrderRefresh implements OrderRefreshInterface {
   /**
    * {@inheritdoc}
    */
-  public function needsRefresh(OrderInterface $order) {
-    // Refresh should only run on draft orders.
-    if ($order->getState()->value != 'draft') {
+  public function shouldRefresh(OrderInterface $order) {
+    if (!$this->needsRefresh($order)) {
       return FALSE;
     }
-
     /** @var \Drupal\commerce_order\Entity\OrderTypeInterface $order_type */
     $order_type = $this->orderTypeStorage->load($order->bundle());
-    // Check the order's changed time against the refresh frequency.
-    // We use time() since the REQUEST_TIME constant can become stale. This is
-    // especially true during CLI operations.
-    if (time() - $order->getChangedTime() < $order_type->getRefreshFrequency()) {
-      return FALSE;
-    }
-
-    // The order should only be refreshed when accessed by its customer.
+    // Ensure the order is only refreshed for its customer, when configured so.
     if ($order_type->getRefreshMode() == OrderType::REFRESH_CUSTOMER) {
       if ($order->getCustomerId() != $this->currentUser->id()) {
         return FALSE;
@@ -98,41 +97,65 @@ class OrderRefresh implements OrderRefreshInterface {
   /**
    * {@inheritdoc}
    */
-  public function refresh(OrderInterface $order) {
-    // Do not attempt to refresh an order that is already refreshing.
-    if (!isset(self::$refreshingOrders[$order->id()])) {
-      self::$refreshingOrders[$order->id()] = TRUE;
-
-      // Do not remove adjustments added in the user interface.
-      $adjustments = $order->getAdjustments();
-      foreach ($adjustments as $key => $adjustment) {
-        if ($adjustment->getType() != 'custom') {
-          unset($adjustments[$key]);
-        }
-      }
-      $order->setAdjustments($adjustments);
-
-      foreach ($order->getItems() as $order_item) {
-        $order_item->setAdjustments([]);
-
-        $purchased_entity = $order_item->getPurchasedEntity();
-        // @todo resolve pricing for items without purchaseable entity.
-        if ($purchased_entity) {
-          $order_item->setTitle($purchased_entity->getOrderItemTitle());
-          $unit_price = $this->chainPriceResolver->resolve($purchased_entity, $order_item->getQuantity());
-          $order_item->setUnitPrice($unit_price);
-        }
-
-        $order_item->save();
-      }
-
-      foreach ($this->processors as $processor) {
-        $processor->process($order);
-      }
-
-      $order->save();
-      unset(self::$refreshingOrders[$order->id()]);
+  public function needsRefresh(OrderInterface $order) {
+    // Only draft orders should be automatically refreshed.
+    if ($order->getState()->value != 'draft') {
+      return FALSE;
     }
+
+    // Accommodate long-running processes by always using the current time.
+    $current_time = $this->time->getCurrentTime();
+    $order_time = $order->getChangedTime();
+    if (date('Y-m-d', $current_time) != date('Y-m-d', $order_time)) {
+      // Refresh on a date change regardless of the refresh frequency.
+      // Date changes can impact tax rate amounts, availability of promotions.
+      return TRUE;
+    }
+    /** @var \Drupal\commerce_order\Entity\OrderTypeInterface $order_type */
+    $order_type = $this->orderTypeStorage->load($order->bundle());
+    $refreshed_ago = $current_time - $order_time;
+    if ($refreshed_ago >= $order_type->getRefreshFrequency()) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function refresh(OrderInterface $order) {
+    // Do not remove adjustments added in the user interface.
+    $adjustments = $order->getAdjustments();
+    foreach ($adjustments as $key => $adjustment) {
+      if ($adjustment->getType() != 'custom') {
+        unset($adjustments[$key]);
+      }
+    }
+    $order->setAdjustments($adjustments);
+
+    foreach ($order->getItems() as $order_item) {
+      $order_item->setAdjustments([]);
+
+      $purchased_entity = $order_item->getPurchasedEntity();
+      if ($purchased_entity) {
+        $order_item->setTitle($purchased_entity->getOrderItemTitle());
+        $unit_price = $this->chainPriceResolver->resolve($purchased_entity, $order_item->getQuantity());
+        $order_item->setUnitPrice($unit_price);
+      }
+    }
+
+    // Allow the processors to modify the order and its items.
+    foreach ($this->processors as $processor) {
+      $processor->process($order);
+    }
+
+    // @todo Evaluate which order items have changed.
+    foreach ($order->getItems() as $order_item) {
+      $order_item->save();
+    }
+
+    $order->setChangedTime($this->time->getCurrentTime());
   }
 
 }

--- a/modules/order/src/OrderRefreshInterface.php
+++ b/modules/order/src/OrderRefreshInterface.php
@@ -20,24 +20,45 @@ interface OrderRefreshInterface {
   public function addProcessor(OrderProcessorInterface $processor, $priority);
 
   /**
-   * Checks if an order needs a refresh.
+   * Checks whether the order should be refreshed.
+   *
+   * Wraps the needsRefresh() check with an additional refresh mode check,
+   * skipping the refresh for non-customers when specified.
    *
    * @param \Drupal\commerce_order\Entity\OrderInterface $order
    *   The order.
    *
    * @return bool
-   *   TRUE if the order needs to be refreshed.
+   *   TRUE if the order should be refreshed, FALSE otherwise.
+   */
+  public function shouldRefresh(OrderInterface $order);
+
+  /**
+   * Checks whether the given order needs to be refreshed.
+   *
+   * An order needs to be refreshed:
+   * - If a refresh was explicitly requested via $order->setNeedsRefresh() due
+   *   to the order being modified.
+   * - If it was not refreshed today (date changes can affect tax rate amounts,
+   *   promotion availability)
+   * - If it was not refreshed for longer than the refresh frequency.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The order.
+   *
+   * @return bool
+   *   TRUE if the order needs to be refreshed, FALSE otherwise.
    */
   public function needsRefresh(OrderInterface $order);
 
   /**
-   * Refreshes an order.
+   * Refreshes the given order.
    *
    * @param \Drupal\commerce_order\Entity\OrderInterface $order
    *   The order.
    *
    * @return \Drupal\commerce_order\Entity\OrderInterface
-   *   The order, refreshed.
+   *   The refreshed, unsaved order.
    */
   public function refresh(OrderInterface $order);
 

--- a/modules/order/src/OrderStorage.php
+++ b/modules/order/src/OrderStorage.php
@@ -3,6 +3,8 @@
 namespace Drupal\commerce_order;
 
 use Drupal\commerce\CommerceContentEntityStorage;
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Database\Connection;
@@ -83,10 +85,33 @@ class OrderStorage extends CommerceContentEntityStorage {
   /**
    * {@inheritdoc}
    */
+  protected function doPreSave(EntityInterface $entity) {
+    $id = parent::doPreSave($entity);
+    /** @var \Drupal\commerce_order\Entity\OrderInterface $entity */
+    if ($entity->getRefreshState() == OrderInterface::REFRESH_ON_SAVE) {
+      $this->orderRefresh->refresh($entity);
+    }
+    // Only the REFRESH_ON_LOAD state needs to be persisted on the entity.
+    if ($entity->getRefreshState() != OrderInterface::REFRESH_ON_LOAD) {
+      $entity->setRefreshState(NULL);
+    }
+
+    return $id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   protected function postLoad(array &$entities) {
-    foreach ($entities as $entity) {
-      if (!$this->skipRefresh && $this->orderRefresh->needsRefresh($entity)) {
-        $this->orderRefresh->refresh($entity);
+    if (!$this->skipRefresh) {
+      /** @var \Drupal\commerce_order\Entity\OrderInterface[] $entities */
+      foreach ($entities as $entity) {
+        $explicitly_requested = $entity->getRefreshState() == OrderInterface::REFRESH_ON_LOAD;
+        if ($explicitly_requested || $this->orderRefresh->shouldRefresh($entity)) {
+          // Reuse the doPostLoad logic.
+          $entity->setRefreshState(OrderInterface::REFRESH_ON_SAVE);
+          $entity->save();
+        }
       }
     }
 

--- a/modules/order/tests/src/Kernel/Entity/OrderTest.php
+++ b/modules/order/tests/src/Kernel/Entity/OrderTest.php
@@ -118,6 +118,8 @@ class OrderTest extends EntityKernelTestBase {
    * @covers ::recalculateTotalPrice
    * @covers ::getTotalPrice
    * @covers ::getState
+   * @covers ::getRefreshState
+   * @covers ::setRefreshState
    * @covers ::getData
    * @covers ::setData
    * @covers ::getCreatedTime
@@ -229,6 +231,9 @@ class OrderTest extends EntityKernelTestBase {
     $this->assertEquals(new Price('27.00', 'USD'), $order->getTotalPrice());
 
     $this->assertEquals('completed', $order->getState()->value);
+
+    $order->setRefreshState(Order::REFRESH_ON_SAVE);
+    $this->assertEquals(Order::REFRESH_ON_SAVE, $order->getRefreshState());
 
     $data = $order->getData();
     $data['test'] = TRUE;

--- a/src/Time.php
+++ b/src/Time.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\commerce;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Provides a class for obtaining system time.
+ *
+ * A copy of the Time class that exists in Drupal 8.3.x.
+ *
+ * @todo Replace with the core class once we start depending on 8.3.x.
+ */
+class Time implements TimeInterface {
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * Constructs a Time object.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
+   */
+  public function __construct(RequestStack $request_stack) {
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * @{inheritdoc}
+   */
+  public function getRequestTime() {
+    return $this->requestStack->getCurrentRequest()->server->get('REQUEST_TIME');
+  }
+
+  /**
+   * @{inheritdoc}
+   */
+  public function getRequestMicroTime() {
+    return $this->requestStack->getCurrentRequest()->server->get('REQUEST_TIME_FLOAT');
+  }
+
+  /**
+   * @{inheritdoc}
+   */
+  public function getCurrentTime() {
+    return time();
+  }
+
+  /**
+   * @{inheritdoc}
+   */
+  public function getCurrentMicroTime() {
+    return microtime(TRUE);
+  }
+
+}

--- a/src/TimeInterface.php
+++ b/src/TimeInterface.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\commerce;
+
+/**
+ * Defines an interface for obtaining system time.
+ *
+ * A copy of the TimeInterface that exists in Drupal 8.3.x.
+ *
+ * @todo Replace with the core interface once we start depending on 8.3.x.
+ */
+interface TimeInterface {
+
+  /**
+   * Returns the timestamp for the current request.
+   *
+   * This method should be used to obtain the current system time at the start
+   * of the request. It will be the same value for the life of the request
+   * (even for long execution times).
+   *
+   * Using the time service, rather than other methods, is especially important
+   * when creating tests, which require predictable timestamps.
+   *
+   * @return int
+   *   A Unix timestamp.
+   *
+   * @see \Drupal\Component\Datetime\TimeInterface::getRequestMicroTime()
+   * @see \Drupal\Component\Datetime\TimeInterface::getCurrentTime()
+   * @see \Drupal\Component\Datetime\TimeInterface::getCurrentMicroTime()
+   */
+  public function getRequestTime();
+
+  /**
+   * Returns the timestamp for the current request with microsecond precision.
+   *
+   * This method should be used to obtain the current system time, with
+   * microsecond precision, at the start of the request. It will be the same
+   * value for the life of the request (even for long execution times).
+   *
+   * Using the time service, rather than other methods, is especially important
+   * when creating tests, which require predictable timestamps.
+   *
+   * @return float
+   *   A Unix timestamp with a fractional portion.
+   *
+   * @see \Drupal\Component\Datetime\TimeInterface::getRequestTime()
+   * @see \Drupal\Component\Datetime\TimeInterface::getCurrentTime()
+   * @see \Drupal\Component\Datetime\TimeInterface::getCurrentMicroTime()
+   */
+  public function getRequestMicroTime();
+
+  /**
+   * Returns the current system time as an integer.
+   *
+   * This method should be used to obtain the current system time, at the time
+   * the method was called.
+   *
+   * This method should only be used when the current system time is actually
+   * needed, such as with timers or time interval calculations. If only the
+   * time at the start of the request is needed,
+   * use TimeInterface::getRequestTime().
+   *
+   * Using the time service, rather than other methods, is especially important
+   * when creating tests, which require predictable timestamps.
+   *
+   * @return int
+   *   A Unix timestamp.
+   *
+   * @see \Drupal\Component\Datetime\TimeInterface::getRequestTime()
+   * @see \Drupal\Component\Datetime\TimeInterface::getRequestMicroTime()
+   * @see \Drupal\Component\Datetime\TimeInterface::getCurrentMicroTime()
+   */
+  public function getCurrentTime();
+
+  /**
+   * Returns the current system time with microsecond precision.
+   *
+   * This method should be used to obtain the current system time, with
+   * microsecond precision, at the time the method was called.
+   *
+   * This method should only be used when the current system time is actually
+   * needed, such as with timers or time interval calculations. If only the
+   * time at the start of the request and microsecond precision is needed,
+   * use TimeInterface::getRequestMicroTime().
+   *
+   * Using the time service, rather than other methods, is especially important
+   * when creating tests, which require predictable timestamps.
+   *
+   * @return float
+   *   A Unix timestamp with a fractional portion.
+   *
+   * @see \Drupal\Component\Datetime\TimeInterface::getRequestTime()
+   * @see \Drupal\Component\Datetime\TimeInterface::getRequestMicroTime()
+   * @see \Drupal\Component\Datetime\TimeInterface::getCurrentTime()
+   */
+  public function getCurrentMicroTime();
+
+}

--- a/tests/modules/commerce_test/commerce_test.services.yml
+++ b/tests/modules/commerce_test/commerce_test.services.yml
@@ -1,5 +1,5 @@
 services:
-  commerce_test.test_availability_manager:
+  commerce_test.test_availability_checker:
     class: Drupal\commerce_test\TestAvailabilityChecker
     tags:
       - { name: commerce.availability_checker }


### PR DESCRIPTION
- Added getRefreshState() and setRefreshState() to orders.
- Added a guarantee that order refresh frequency is always at least 1s, used it to remove the static from OrderRefresh
- Improved the order refresh frequency form element (OrderTypeForm)
- Changed the default refresh frequency to 300s (5min), default refresh mode to "customer" (matching 1.x)
- Added logic that always refreshes if the day has changed.
- Split needsRefresh into needsRefresh and shouldRefresh. Allows us to show a message to the admin saying "looks like this order needs to be refreshed, would you like to do that?"
- Rewrote the order refresh tests.
- Fixed bug where order items were saved before the processors had a chance to modify them.
- Fixed wrong typehint for $current_user.
- Copied the Drupal 8.3.x Time object into Commerce, added it to the refresh process.
