### PR TITLE
Issue #2708455 - Cart totals are not updated on updating line items

### DIFF
--- a/modules/cart/src/CartManager.php
+++ b/modules/cart/src/CartManager.php
@@ -129,12 +129,15 @@ class CartManager implements CartManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function updateOrderItem(OrderInterface $cart, OrderItemInterface $order_item) {
+  public function updateOrderItem(OrderInterface $cart, OrderItemInterface $order_item, $save_cart = TRUE) {
     /** @var \Drupal\commerce_order\Entity\OrderItemInterface $original_order_item */
     $original_order_item = $this->orderItemStorage->loadUnchanged($order_item->id());
     $order_item->save();
     $event = new CartOrderItemUpdateEvent($cart, $order_item, $original_order_item);
     $this->eventDispatcher->dispatch(CartEvents::CART_ORDER_ITEM_UPDATE, $event);
+    if ($save_cart) {
+      $cart->save();
+    }
   }
 
   /**

--- a/modules/cart/src/CartManager.php
+++ b/modules/cart/src/CartManager.php
@@ -81,7 +81,8 @@ class CartManager implements CartManagerInterface {
    */
   public function addEntity(OrderInterface $cart, PurchasableEntityInterface $entity, $quantity = 1, $combine = TRUE, $save_cart = TRUE) {
     $order_item = $this->createOrderItem($entity, $quantity);
-    return $this->addOrderItem($cart, $order_item, $combine);
+
+    return $this->addOrderItem($cart, $order_item, $combine, $save_cart);
   }
 
   /**
@@ -105,7 +106,6 @@ class CartManager implements CartManagerInterface {
     if ($combine) {
       $matching_order_item = $this->orderItemMatcher->match($order_item, $cart->getItems());
     }
-    $needs_cart_save = FALSE;
     if ($matching_order_item) {
       $new_quantity = Calculator::add($matching_order_item->getQuantity(), $quantity);
       $matching_order_item->setQuantity($new_quantity);
@@ -114,12 +114,11 @@ class CartManager implements CartManagerInterface {
     else {
       $order_item->save();
       $cart->addItem($order_item);
-      $needs_cart_save = TRUE;
     }
 
     $event = new CartEntityAddEvent($cart, $purchased_entity, $quantity, $order_item);
     $this->eventDispatcher->dispatch(CartEvents::CART_ENTITY_ADD, $event);
-    if ($needs_cart_save && $save_cart) {
+    if ($save_cart) {
       $cart->save();
     }
 

--- a/modules/cart/src/CartManager.php
+++ b/modules/cart/src/CartManager.php
@@ -81,7 +81,6 @@ class CartManager implements CartManagerInterface {
    */
   public function addEntity(OrderInterface $cart, PurchasableEntityInterface $entity, $quantity = 1, $combine = TRUE, $save_cart = TRUE) {
     $order_item = $this->createOrderItem($entity, $quantity);
-
     return $this->addOrderItem($cart, $order_item, $combine, $save_cart);
   }
 

--- a/modules/cart/src/CartManagerInterface.php
+++ b/modules/cart/src/CartManagerInterface.php
@@ -77,8 +77,10 @@ interface CartManagerInterface {
    *   The cart order.
    * @param \Drupal\commerce_order\Entity\OrderItemInterface $order_item
    *   The order item.
+   * @param bool $save_cart
+   *   Whether the cart should be saved after the operation.
    */
-  public function updateOrderItem(OrderInterface $cart, OrderItemInterface $order_item);
+  public function updateOrderItem(OrderInterface $cart, OrderItemInterface $order_item, $save_cart = TRUE);
 
   /**
    * Removes the given order item from the cart order.


### PR DESCRIPTION
1. `updateOrderItem` now has a `save_cart` flag, defaults to saving the cart after update, like the rest of the methods.
2. `addEntity` now passes along the `save_cart` flag to `addOrderItem`, as it was previously unused in `addEntity`.
3. `addOrderItem` now only determines to save the cart based on the `save_cart` flag, removing the unneeded and problematic `needs_cart_save` var (which was only true when a new item was added, and not true when an order item that already exists in the cart was added by the user).

This set of changes will get the test in #547 to pass.