### PR TITLE
adding explicit NULL return statements to chain resolvers

### DIFF
--- a/modules/order/src/Resolver/ChainOrderTypeResolver.php
+++ b/modules/order/src/Resolver/ChainOrderTypeResolver.php
@@ -50,6 +50,7 @@ class ChainOrderTypeResolver implements ChainOrderTypeResolverInterface {
         return $result;
       }
     }
+    return NULL;
   }
 
 }

--- a/modules/price/src/Resolver/ChainPriceResolver.php
+++ b/modules/price/src/Resolver/ChainPriceResolver.php
@@ -50,6 +50,7 @@ class ChainPriceResolver implements ChainPriceResolverInterface {
         return $result;
       }
     }
+    return NULL;
   }
 
 }

--- a/modules/store/src/Resolver/ChainStoreResolver.php
+++ b/modules/store/src/Resolver/ChainStoreResolver.php
@@ -48,6 +48,7 @@ class ChainStoreResolver implements ChainStoreResolverInterface {
         return $result;
       }
     }
+    return NULL;
   }
 
 }

--- a/src/Resolver/ChainCountryResolver.php
+++ b/src/Resolver/ChainCountryResolver.php
@@ -48,6 +48,7 @@ class ChainCountryResolver implements ChainCountryResolverInterface {
         return $result;
       }
     }
+    return NULL;
   }
 
 }

--- a/src/Resolver/ChainLocaleResolver.php
+++ b/src/Resolver/ChainLocaleResolver.php
@@ -48,6 +48,7 @@ class ChainLocaleResolver implements ChainLocaleResolverInterface {
         return $result;
       }
     }
+    return NULL;
   }
 
 }


### PR DESCRIPTION
found this by accident. It's a little code style improvement. All chain resolvers just exit their resolve() functions, if no resolution was achieved. This PR is adding explicit NULL returns.