### PR TITLE
Issue #2829487 by drugan: Make configurable auto SKU widget

### DIFF
--- a/config/schema/commerce.schema.yml
+++ b/config/schema/commerce.schema.yml
@@ -33,6 +33,29 @@ field.field_settings.commerce_plugin_item:*:
       sequence:
         - type: string
 
+field.widget.settings.commerce_auto_sku:
+  type: mapping
+  label: 'Commerce auto SKU format settings'
+  mapping:
+    iniqid_enabled:
+      type: boolean
+      label: 'Enable unique auto SKU values generation'
+    more_entropy:
+      type: boolean
+      label: 'More unique'
+    prefix:
+      type: string
+      label: 'SKU prefix'
+    suffix:
+      type: string
+      label: 'SKU suffix'
+    size:
+      type: integer
+      label: 'Size of textfield'
+    placeholder:
+      type: label
+      label: 'Placeholder'
+
 views.argument_validator.commerce_current_user:
   type: mapping
   label: 'Current user'

--- a/config/schema/commerce.schema.yml
+++ b/config/schema/commerce.schema.yml
@@ -37,7 +37,7 @@ field.widget.settings.commerce_auto_sku:
   type: mapping
   label: 'Commerce auto SKU format settings'
   mapping:
-    iniqid_enabled:
+    uniqid_enabled:
       type: boolean
       label: 'Enable unique auto SKU values generation'
     more_entropy:

--- a/config/schema/commerce.schema.yml
+++ b/config/schema/commerce.schema.yml
@@ -51,7 +51,7 @@ field.widget.settings.commerce_auto_sku:
       label: 'SKU suffix'
     size:
       type: integer
-      label: 'Size of textfield'
+      label: 'Size of SKU field'
     placeholder:
       type: label
       label: 'Placeholder'

--- a/modules/product/config/install/core.entity_form_display.commerce_product_variation.default.default.yml
+++ b/modules/product/config/install/core.entity_form_display.commerce_product_variation.default.default.yml
@@ -19,7 +19,7 @@ content:
     type: commerce_auto_sku
     weight: -4
     settings:
-      iniqid_enabled: true
+      uniqid_enabled: true
       more_entropy: false
       prefix: 'sku-'
       suffix: ''

--- a/modules/product/config/install/core.entity_form_display.commerce_product_variation.default.default.yml
+++ b/modules/product/config/install/core.entity_form_display.commerce_product_variation.default.default.yml
@@ -16,9 +16,13 @@ content:
     settings: {  }
     third_party_settings: {  }
   sku:
-    type: string_textfield
+    type: commerce_auto_sku
     weight: -4
     settings:
+      iniqid_enabled: true
+      more_entropy: false
+      prefix: 'sku-'
+      suffix: ''
       size: 60
       placeholder: ''
     third_party_settings: {  }

--- a/src/Plugin/Field/FieldWidget/ProductVariationSkuWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProductVariationSkuWidget.php
@@ -90,7 +90,7 @@ class ProductVariationSkuWidget extends StringTextfieldWidget {
     $summary = [];
     $none = $this->t('None');
     $settings = $this->getSettings();
-    $sku =  uniqid($settings['prefix'], $settings['more_entropy']) . $settings['suffix'];
+    $sku = uniqid($settings['prefix'], $settings['more_entropy']) . $settings['suffix'];
     $settings['auto SKU sample'] = $settings['uniqid_enabled'] ? $sku : $none;
     unset($settings['uniqid_enabled'], $settings['more_entropy']);
     foreach ($settings as $name => $value) {

--- a/src/Plugin/Field/FieldWidget/ProductVariationSkuWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProductVariationSkuWidget.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\commerce\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\Plugin\Field\FieldWidget\StringTextfieldWidget;
+
+/**
+ * Plugin implementation of the 'commerce_auto_sku' widget.
+ *
+ * @FieldWidget(
+ *   id = "commerce_auto_sku",
+ *   label = @Translation("Commerce auto SKU"),
+ *   field_types = {
+ *     "string"
+ *   }
+ * )
+ */
+class ProductVariationSkuWidget extends StringTextfieldWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return array(
+      'iniqid_enabled' => TRUE,
+      'more_entropy' => FALSE,
+      'prefix' => 'sku-',
+      'suffix' => '',
+      'size' => 60,
+      'placeholder' => '',
+    ) + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $none = t('None');
+    $settings = $this->getSettings();
+    $element['iniqid_enabled'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Enable unique auto SKU values generation'),
+      '#default_value' => $settings['iniqid_enabled'],
+    );
+    $element['more_entropy'] = array(
+      '#type' => 'checkbox',
+      '#title_display' => 'before',
+      '#title' => t('More unique'),
+      '#description' => t('If unchecked the SKU (without prefix and suffix) will look like this: <strong>@short</strong>. If checked, like this: <strong>@long</strong>. <a href=":uniqid_href" target="_blank">Read more</a>', [':uniqid_href' => 'http://php.net/manual/en/function.uniqid.php', '@short' => uniqid(), '@long' => uniqid('', TRUE)]),
+      '#default_value' => $settings['more_entropy'],
+      '#states' => array(
+        'visible' => [':input[name*="iniqid_enabled"]' => ['checked' => TRUE]],
+      ),
+    );
+    $element['prefix'] = array(
+      '#type' => 'textfield',
+      '#title' => t('SKU prefix'),
+      '#default_value' => $settings['prefix'],
+      '#placeholder' => $none,
+    );
+    $element['suffix'] = array(
+      '#type' => 'textfield',
+      '#title' => t('SKU suffix'),
+      '#default_value' => $settings['suffix'],
+      '#placeholder' => $none,
+    );
+    $element['size'] = array(
+      '#type' => 'number',
+      '#title' => t('Size of textfield'),
+      '#default_value' => $settings['size'],
+      '#required' => TRUE,
+      '#min' => 1,
+    );
+    $element['placeholder'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Placeholder'),
+      '#default_value' => $settings['placeholder'],
+      '#description' => t('Text that will be shown inside the field until a value is entered. This hint is usually a sample value or a brief description of the expected format.'),
+      '#placeholder' => $none,
+    );
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = array();
+    $none = t('None');
+    $settings = $this->getSettings();
+    $settings['Uniqueness sample'] = $settings['iniqid_enabled'] ? ($settings['more_entropy'] ? uniqid('', TRUE) : uniqid()) : $none;
+    unset($settings['iniqid_enabled'], $settings['more_entropy']);
+    foreach ($settings as $name => $value) {
+      $value = empty($settings[$name]) ? $none : $value;
+      $summary[] = "{$name}: {$value}";
+    }
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element['value'] = $element + array(
+      '#type' => 'textfield',
+      '#default_value' => isset($items[$delta]->value) ? $items[$delta]->value : NULL,
+      '#size' => $this->getSetting('size'),
+      '#placeholder' => $this->getSetting('placeholder'),
+      '#maxlength' => $this->getFieldSetting('max_length'),
+      '#attributes' => array('class' => array('js-text-full', 'text-full')),
+    );
+
+    return $element;
+  }
+
+}

--- a/src/Plugin/Field/FieldWidget/ProductVariationSkuWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProductVariationSkuWidget.php
@@ -23,63 +23,63 @@ class ProductVariationSkuWidget extends StringTextfieldWidget {
    * {@inheritdoc}
    */
   public static function defaultSettings() {
-    return array(
-      'iniqid_enabled' => TRUE,
+    return [
+      'uniqid_enabled' => TRUE,
       'more_entropy' => FALSE,
       'prefix' => 'sku-',
       'suffix' => '',
       'size' => 60,
       'placeholder' => '',
-    ) + parent::defaultSettings();
+    ] + parent::defaultSettings();
   }
 
   /**
    * {@inheritdoc}
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
-    $none = t('None');
+    $none = $this->t('None');
     $settings = $this->getSettings();
-    $element['iniqid_enabled'] = array(
+    $element['uniqid_enabled'] = [
       '#type' => 'checkbox',
-      '#title' => t('Enable unique auto SKU values generation'),
-      '#default_value' => $settings['iniqid_enabled'],
-    );
-    $element['more_entropy'] = array(
+      '#title' => $this->t('Enable unique auto SKU values generation'),
+      '#default_value' => $settings['uniqid_enabled'],
+    ];
+    $element['more_entropy'] = [
       '#type' => 'checkbox',
       '#title_display' => 'before',
-      '#title' => t('More unique'),
-      '#description' => t('If unchecked the SKU (without prefix and suffix) will look like this: <strong>@short</strong>. If checked, like this: <strong>@long</strong>. <a href=":uniqid_href" target="_blank">Read more</a>', [':uniqid_href' => 'http://php.net/manual/en/function.uniqid.php', '@short' => uniqid(), '@long' => uniqid('', TRUE)]),
+      '#title' => $this->t('More unique'),
+      '#description' => $this->t('If unchecked the SKU (without prefix and suffix) will look like this: <strong>@short</strong>. If checked, like this: <strong>@long</strong>. <a href=":uniqid_href" target="_blank">Read more</a>', [':uniqid_href' => 'http://php.net/manual/en/function.uniqid.php', '@short' => uniqid(), '@long' => uniqid('', TRUE)]),
       '#default_value' => $settings['more_entropy'],
-      '#states' => array(
-        'visible' => [':input[name*="iniqid_enabled"]' => ['checked' => TRUE]],
-      ),
-    );
-    $element['prefix'] = array(
+      '#states' => [
+        'visible' => [':input[name*="uniqid_enabled"]' => ['checked' => TRUE]],
+      ],
+    ];
+    $element['prefix'] = [
       '#type' => 'textfield',
-      '#title' => t('SKU prefix'),
+      '#title' => $this->t('SKU prefix'),
       '#default_value' => $settings['prefix'],
       '#placeholder' => $none,
-    );
-    $element['suffix'] = array(
+    ];
+    $element['suffix'] = [
       '#type' => 'textfield',
-      '#title' => t('SKU suffix'),
+      '#title' => $this->t('SKU suffix'),
       '#default_value' => $settings['suffix'],
       '#placeholder' => $none,
-    );
-    $element['size'] = array(
+    ];
+    $element['size'] = [
       '#type' => 'number',
-      '#title' => t('Size of textfield'),
+      '#title' => $this->t('Size of SKU field'),
       '#default_value' => $settings['size'],
       '#required' => TRUE,
       '#min' => 1,
-    );
-    $element['placeholder'] = array(
+    ];
+    $element['placeholder'] = [
       '#type' => 'textfield',
-      '#title' => t('Placeholder'),
+      '#title' => $this->t('Placeholder'),
       '#default_value' => $settings['placeholder'],
-      '#description' => t('Text that will be shown inside the field until a value is entered. This hint is usually a sample value or a brief description of the expected format.'),
+      '#description' => $this->t('Text that will be shown inside the field until a value is entered. This hint is usually a sample value or a brief description of the expected format.'),
       '#placeholder' => $none,
-    );
+    ];
     return $element;
   }
 
@@ -87,11 +87,12 @@ class ProductVariationSkuWidget extends StringTextfieldWidget {
    * {@inheritdoc}
    */
   public function settingsSummary() {
-    $summary = array();
-    $none = t('None');
+    $summary = [];
+    $none = $this->t('None');
     $settings = $this->getSettings();
-    $settings['Uniqueness sample'] = $settings['iniqid_enabled'] ? ($settings['more_entropy'] ? uniqid('', TRUE) : uniqid()) : $none;
-    unset($settings['iniqid_enabled'], $settings['more_entropy']);
+    $sku =  uniqid($settings['prefix'], $settings['more_entropy']) . $settings['suffix'];
+    $settings['auto SKU sample'] = $settings['uniqid_enabled'] ? $sku : $none;
+    unset($settings['uniqid_enabled'], $settings['more_entropy']);
     foreach ($settings as $name => $value) {
       $value = empty($settings[$name]) ? $none : $value;
       $summary[] = "{$name}: {$value}";
@@ -104,14 +105,14 @@ class ProductVariationSkuWidget extends StringTextfieldWidget {
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-    $element['value'] = $element + array(
+    $element['value'] = $element + [
       '#type' => 'textfield',
       '#default_value' => isset($items[$delta]->value) ? $items[$delta]->value : NULL,
       '#size' => $this->getSetting('size'),
       '#placeholder' => $this->getSetting('placeholder'),
       '#maxlength' => $this->getFieldSetting('max_length'),
-      '#attributes' => array('class' => array('js-text-full', 'text-full')),
-    );
+      '#attributes' => ['class' => ['js-text-full', 'text-full']],
+    ];
 
     return $element;
   }


### PR DESCRIPTION
As it were suggested by mglaman in [#545](https://github.com/drupalcommerce/commerce/pull/545) the auto SKU widget is moved to core and [issue #2829487 ](https://www.drupal.org/node/2829487) is open.