### PR TITLE
Add support for manually created attribute fields

### DIFF
--- a/modules/product/src/Plugin/Field/FieldWidget/ProductVariationAttributesWidget.php
+++ b/modules/product/src/Plugin/Field/FieldWidget/ProductVariationAttributesWidget.php
@@ -232,10 +232,11 @@ class ProductVariationAttributesWidget extends ProductVariationWidgetBase implem
     $field_definitions = $this->attributeFieldManager->getFieldDefinitions($selected_variation->bundle());
     $field_map = $this->attributeFieldManager->getFieldMap($selected_variation->bundle());
     $field_names = array_column($field_map, 'field_name');
+    $attribute_names = array_column($field_map, 'attribute_id');
     $index = 0;
     foreach ($field_names as $field_name) {
       /** @var \Drupal\commerce_product\Entity\ProductAttributeInterface $attribute_type */
-      $attribute_type = $this->attributeStorage->load(substr($field_name, 10));
+      $attribute_type = $this->attributeStorage->load($attribute_names[$index]);
       $field = $field_definitions[$field_name];
       $attributes[$field_name] = [
         'field_name' => $field_name,


### PR DESCRIPTION
Use the attribute names from the field_map. Fixes fatal error for custom product types, because $attribute_type object in line 240 is always NULL, because the name in load method is always wrong