### PR TITLE
In case resolver returns other currency

### DIFF
--- a/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
@@ -85,7 +85,7 @@ class PriceCalculatedFormatter extends PriceDefaultFormatter implements Containe
       $container->get('entity_type.manager'),
       $container->get('commerce_price.number_formatter_factory'),
       $container->get('commerce_price.chain_price_resolver'),
-      $container->get('entity.manager')->getStorage('commerce_currency'),
+      $container->get('entity.manager')->getStorage('commerce_currency')
     );
   }
 

--- a/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
@@ -84,11 +84,7 @@ class PriceCalculatedFormatter extends PriceDefaultFormatter implements Containe
    * {@inheritdoc}
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
-    $currency_codes = [];
-    foreach ($items as $delta => $item) {
-      $currency_codes[] = $item->currency_code;
-    }
-    $currencies = $this->currencyStorage->loadMultiple($currency_codes);
+    $currencies = $this->currencyStorage->loadMultiple();
 
     $elements = [];
     /** @var \Drupal\commerce_price\Plugin\Field\FieldType\PriceItem $item */

--- a/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
@@ -7,7 +7,6 @@ use Drupal\commerce_price\NumberFormatterFactoryInterface;
 use Drupal\commerce_price\Resolver\ChainPriceResolverInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Language\LanguageInterface;
@@ -35,6 +34,7 @@ class PriceCalculatedFormatter extends PriceDefaultFormatter implements Containe
   protected $chainPriceResolver;
   
   /**
+   * Currency storage interface
    *
    * @var \Drupal\commerce_price\Entity\CurrencyInterface
    */
@@ -64,10 +64,10 @@ class PriceCalculatedFormatter extends PriceDefaultFormatter implements Containe
    * @param \Drupal\commerce_price\Resolver\ChainPriceResolverInterface $chain_price_resolver
    *   The chain price resolver.
    */
-  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager, NumberFormatterFactoryInterface $number_formatter_factory, ChainPriceResolverInterface $chain_price_resolver, EntityStorageInterface $currency_storage) {
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager, NumberFormatterFactoryInterface $number_formatter_factory, ChainPriceResolverInterface $chain_price_resolver) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings, $entity_type_manager, $number_formatter_factory);
     $this->chainPriceResolver = $chain_price_resolver;
-    $this->currencyStorage = $currency_storage;
+    $this->currencyStorage = $entity_type_manager->getStorage('commerce_currency');
   }
 
   /**
@@ -84,8 +84,7 @@ class PriceCalculatedFormatter extends PriceDefaultFormatter implements Containe
       $configuration['third_party_settings'],
       $container->get('entity_type.manager'),
       $container->get('commerce_price.number_formatter_factory'),
-      $container->get('commerce_price.chain_price_resolver'),
-      $container->get('entity.manager')->getStorage('commerce_currency')
+      $container->get('commerce_price.chain_price_resolver')
     );
   }
 

--- a/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
@@ -34,12 +34,12 @@ class PriceCalculatedFormatter extends PriceDefaultFormatter implements Containe
   protected $chainPriceResolver;
   
   /**
-   * Currency storage interface
+   * Currency storage interface.
    *
    * @var \Drupal\commerce_price\Entity\CurrencyInterface
    */
   protected $currencyStorage;
-  
+
   /**
    * Constructs a new PriceCalculatedFormatter object.
    *

--- a/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
+++ b/modules/price/src/Plugin/Field/FieldFormatter/PriceCalculatedFormatter.php
@@ -32,7 +32,7 @@ class PriceCalculatedFormatter extends PriceDefaultFormatter implements Containe
    * @var \Drupal\commerce_price\Resolver\ChainPriceResolverInterface
    */
   protected $chainPriceResolver;
-  
+
   /**
    * Currency storage interface.
    *


### PR DESCRIPTION
In the case if resolver returns the price in different currency we need this currency object to be format in correctly. By default $items variable has only the default currency code inside.