### PR TITLE
Fixed creating offsite payment method

### DIFF
--- a/modules/payment/src/PluginForm/PaymentMethodAddForm.php
+++ b/modules/payment/src/PluginForm/PaymentMethodAddForm.php
@@ -85,7 +85,8 @@ class PaymentMethodAddForm extends PaymentGatewayFormBase {
     // The payment method form is customer facing. For security reasons
     // the returned errors need to be more generic.
     try {
-      $payment_gateway_plugin->createPaymentMethod($payment_method, $values['payment_details']);
+      $paymentDetails = empty($values['payment_details']) ? array() : $values['payment_details'];
+      $payment_gateway_plugin->createPaymentMethod($payment_method, $paymentDetails);
     }
     catch (DeclineException $e) {
       \Drupal::logger('commerce_payment')->warning($e->getMessage());


### PR DESCRIPTION
Fixed fatal error when creating offsite payment method without payment_details

Recoverable fatal error: Argument 2 passed to
Drupal\dibs_payment\Plugin\Commerce\PaymentGateway\DibsPaymentGateway::c
reatePaymentMethod() must be of the type array, null given, called in
/modules/contrib/commerce/modules/payment/src/PluginForm/PaymentMethodAd
dForm.php on line 89 and defined in
/modules/custom/dibs_payment/src/Plugin/Commerce/PaymentGateway/DibsPaym
entGateway.php on line 92 #0 /core/includes/bootstrap.inc(548):
_drupal_error_handler_real(4096, 'Argument 2 pass...',
'/Users/maksim/D...', 92, Array)
#2
/modules/contrib/commerce/modules/payment/src/PluginForm/PaymentMethodAd
dForm.php(89):
Drupal\dibs_payment\Plugin\Commerce\PaymentGateway\DibsPaymentGateway->c
reatePaymentMethod(Object(Drupal\commerce_payment\Entity\PaymentMethod),
NULL)