### PR TITLE
Issue #2832595 - Payments tab on orders no longer shows up

### DIFF
--- a/modules/payment/commerce_payment.links.task.yml
+++ b/modules/payment/commerce_payment.links.task.yml
@@ -1,6 +1,6 @@
 entity.commerce_payment.collection:
   route_name: entity.commerce_payment.collection
-  base_route: entity.commerce_order.edit_form
+  base_route: entity.commerce_order.canonical
   title: Payments
 
 entity.commerce_payment_gateway.edit_form:

--- a/modules/payment/tests/src/Functional/PaymentAdminTest.php
+++ b/modules/payment/tests/src/Functional/PaymentAdminTest.php
@@ -123,6 +123,15 @@ class PaymentAdminTest extends CommerceBrowserTestBase {
   }
 
   /**
+   * Tests that a Payments task link exists on the order page.
+   */
+  public function testPaymentTask() {
+    $this->drupalGet('admin/commerce/orders/' . $this->order->id());
+    $this->assertSession()->linkExists('Payments');
+    $this->assertSession()->linkByHrefExists($this->paymentUri);
+  }
+
+  /**
    * Tests creating a payment for an order.
    */
   public function testPaymentCreation() {


### PR DESCRIPTION
Follow-up to #574.
See https://www.drupal.org/node/2832595.