### PR TITLE
Issue #2827721: AddToCartForm should support all purchasable entities

### DIFF
--- a/modules/cart/src/Form/AddToCartForm.php
+++ b/modules/cart/src/Form/AddToCartForm.php
@@ -140,10 +140,8 @@ class AddToCartForm extends ContentEntityForm {
     if ($this->operation != 'default') {
       $form_id = $form_id . '_' . $this->operation;
     }
-    $product_id = $this->entity->getPurchasedEntity()->getProductId();
-    $str = $product_id . serialize($this->entity->getPurchasedEntity()->toArray());
-    $id = sha1($str);
-    // For the case when on a page 2+ exactly the same add_to_cart forms.
+    $id = sha1(serialize($this->entity->getPurchasedEntity()->toArray()));
+    // For the case when on a page 2+ exactly the same purchased entities.
     while (in_array($id, static::$FormInstanceIds)) {
       $id = sha1($id . $id);
     }

--- a/modules/cart/src/Form/AddToCartForm.php
+++ b/modules/cart/src/Form/AddToCartForm.php
@@ -59,13 +59,11 @@ class AddToCartForm extends ContentEntityForm {
   protected $chainPriceResolver;
 
   /**
-   * The form instance ID.
+   * The form instance IDs of purchased entities.
    *
-   * Numeric counter used to ensure form ID uniqueness.
-   *
-   * @var int
+   * @var array
    */
-  protected static $formInstanceId = 0;
+  protected static $FormInstanceIds = [];
 
   /**
    * The current user.
@@ -105,8 +103,6 @@ class AddToCartForm extends ContentEntityForm {
     $this->storeContext = $store_context;
     $this->chainPriceResolver = $chain_price_resolver;
     $this->currentUser = $current_user;
-
-    self::$formInstanceId++;
   }
 
   /**
@@ -144,9 +140,23 @@ class AddToCartForm extends ContentEntityForm {
     if ($this->operation != 'default') {
       $form_id = $form_id . '_' . $this->operation;
     }
-    $form_id .= '_' . self::$formInstanceId;
+    $product_id = $this->entity->getPurchasedEntity()->getProductId();
+    $str = $product_id . serialize($this->entity->getPurchasedEntity()->toArray());
+    $id = sha1($str);
+    // For the case when on a page 2+ exactly the same add_to_cart forms.
+    while (in_array($id, static::$FormInstanceIds)) {
+      $id = sha1($id . $id);
+    }
+    static::$FormInstanceIds[] = $id;
 
-    return $form_id . '_form';
+    return $form_id . '_' . $id . '_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormInstanceIds() {
+    return static::$FormInstanceIds;
   }
 
   /**

--- a/modules/cart/tests/src/Functional/AddToCartFormTest.php
+++ b/modules/cart/tests/src/Functional/AddToCartFormTest.php
@@ -176,8 +176,7 @@ class AddToCartFormTest extends CartBrowserTestBase {
     $product->save();
     $product_variations = $product->getVariations();
     $current_variation = current($product_variations);
-    $str = $product->id() . serialize($current_variation->toArray());
-    $id = sha1($str);
+    $id = sha1(serialize($current_variation->toArray()));
 
     $this->drupalGet($product->toUrl());
     $this->assertSession()->elementExists('xpath', '//select[@id="edit-purchased-entity-0-attributes-attribute-color-' . $id . '" and @disabled]');
@@ -289,8 +288,7 @@ class AddToCartFormTest extends CartBrowserTestBase {
     $product->save();
     $product_variations = $product->getVariations();
     $current_variation = current($product_variations);
-    $str = $product->id() . serialize($current_variation->toArray());
-    $id = sha1($str);
+    $id = sha1(serialize($current_variation->toArray()));
 
     // The color element should be required because each variation has a color.
     $this->drupalGet($product->toUrl());

--- a/modules/cart/tests/src/Functional/AddToCartFormTest.php
+++ b/modules/cart/tests/src/Functional/AddToCartFormTest.php
@@ -174,9 +174,13 @@ class AddToCartFormTest extends CartBrowserTestBase {
       $product->variations->appendItem($variation);
     }
     $product->save();
+    $product_variations = $product->getVariations();
+    $current_variation = current($product_variations);
+    $str = $product->id() . serialize($current_variation->toArray());
+    $id = sha1($str);
 
     $this->drupalGet($product->toUrl());
-    $this->assertSession()->elementExists('xpath', '//select[@id="edit-purchased-entity-0-attributes-attribute-color" and @disabled]');
+    $this->assertSession()->elementExists('xpath', '//select[@id="edit-purchased-entity-0-attributes-attribute-color-' . $id . '" and @disabled]');
   }
 
   /**
@@ -283,11 +287,15 @@ class AddToCartFormTest extends CartBrowserTestBase {
       $product->variations->appendItem($variation);
     }
     $product->save();
+    $product_variations = $product->getVariations();
+    $current_variation = current($product_variations);
+    $str = $product->id() . serialize($current_variation->toArray());
+    $id = sha1($str);
 
     // The color element should be required because each variation has a color.
     $this->drupalGet($product->toUrl());
     $this->assertSession()->fieldExists('purchased_entity[0][attributes][attribute_size]');
-    $this->assertSession()->elementExists('xpath', '//select[@id="edit-purchased-entity-0-attributes-attribute-color" and @required]');
+    $this->assertSession()->elementExists('xpath', '//select[@id="edit-purchased-entity-0-attributes-attribute-color-' . $id . '" and @required]');
 
     // Remove the color value from all variations.
     // The color element should now be hidden.

--- a/modules/cart/tests/src/Functional/CartBrowserTestBase.php
+++ b/modules/cart/tests/src/Functional/CartBrowserTestBase.php
@@ -230,7 +230,7 @@ abstract class CartBrowserTestBase extends OrderBrowserTestBase {
   }
 
   /**
-   * Helper method to fetch values from an Add to Cart form displayed on a page.
+   * Helper method to fetch values from the Add to Cart form displayed on a page.
    *
    * Works with the following variation attribute form display widgets: select
    * list, radio buttons, rendered attribute and variation titles select list.
@@ -254,7 +254,7 @@ abstract class CartBrowserTestBase extends OrderBrowserTestBase {
    */
   protected function getAddToCartFormValues(BehatNodeElement $form) {
     $values = [];
-    $values['product_id'] = [];
+    $values['product_id'] = '';
     $values['form_id'] = $form->getAttribute('id');
     $grand_parent = $form->getParent()->getParent();
     $title = $grand_parent->find('css', '[class^="product--variation-field--variation_title__"]');
@@ -274,8 +274,8 @@ abstract class CartBrowserTestBase extends OrderBrowserTestBase {
     $attributes = $form->find('css', '[id^="edit-purchased-entity-0-attributes"]') ?: $form->find('css', '.form-item-purchased-entity-0-variation');
     $values['attributes'] = [];
     if (is_object($attributes)) {
-      $attributes = $attributes->findAll('css', '[id^="edit-purchased-entity-0-attributes-attribute-"]');
-      $attributes = $attributes ?: $attributes->findAll('css', '[id^="edit-purchased-entity-0-variation"]');
+      $titles = $attributes->findAll('css', '[id^="edit-purchased-entity-0-variation"]');
+      $attributes = $titles ?: $attributes->findAll('css', '[id^="edit-purchased-entity-0-attributes-attribute-"]');
       if (!empty($attributes)) {
         foreach ($attributes as $attribute) {
           $element = $attribute->getTagName();
@@ -292,7 +292,6 @@ abstract class CartBrowserTestBase extends OrderBrowserTestBase {
           }
           elseif ($element == 'fieldset' && $legend = $attribute->find('css', '.fieldset-legend')) {
             $field_label = $legend->getText();
-            $checked = $attribute->find('css', '.form-radios')->find('css', 'input[checked="checked"]');
             foreach ($attribute->findAll('named', ['radio', '']) as $radio) {
               $values['attributes'][$field_label][$radio->isChecked() ? 'chosen' : 'ignored'][] = [
                 'label' => $radio->getParent()->find('css', '[for^="edit-purchased-entity-0-attributes-attribute-"]')->getText(),

--- a/modules/cart/tests/src/Functional/CartBrowserTestBase.php
+++ b/modules/cart/tests/src/Functional/CartBrowserTestBase.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\Entity\EntityViewDisplay;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Tests\commerce_order\Functional\OrderBrowserTestBase;
+use Behat\Mink\Element\NodeElement as BehatNodeElement;
 
 /**
  * Defines base class for commerce_cart test cases.
@@ -236,6 +237,7 @@ abstract class CartBrowserTestBase extends OrderBrowserTestBase {
    *
    * @param \Behat\Mink\Element\NodeElement $form
    *   The Add to Cart form object.
+   *
    * @return array
    *   The array of values:
    *   - "product_id": The form parent product ID.
@@ -250,7 +252,7 @@ abstract class CartBrowserTestBase extends OrderBrowserTestBase {
    *
    * @see \Drupal\Tests\commerce_cart\FunctionalJavascript\MultipleCartFormsTest->testMultipleCartsOnPage()
    */
-  protected function getAddToCartFormValues(NodeElement $form) {
+  protected function getAddToCartFormValues(BehatNodeElement $form) {
     $values = [];
     $values['product_id'] = [];
     $values['form_id'] = $form->getAttribute('id');
@@ -310,6 +312,7 @@ abstract class CartBrowserTestBase extends OrderBrowserTestBase {
    *
    * @param \Behat\Mink\Element\NodeElement $cart
    *   The Shopping Cart form object.
+   *
    * @return array
    *   The array of order items having the following values:
    *   - "title": The title of an order item.
@@ -319,9 +322,9 @@ abstract class CartBrowserTestBase extends OrderBrowserTestBase {
    *
    * @see \Drupal\Tests\commerce_cart\FunctionalJavascript\MultipleCartFormsTest->assertAddToCartFormValues()
    */
-  protected function getShoppingCartValues(NodeElement $cart) {
+  protected function getShoppingCartValues(BehatNodeElement $cart) {
     $order_items = [];
-    foreach ($cart->findAll('css','td.views-field-purchased-entity') as $item) {
+    foreach ($cart->findAll('css', 'td.views-field-purchased-entity') as $item) {
       $row = $item->getParent();
       $order_items[] = [
         'title' => $row->find('css', '.field--name-title')->getText(),

--- a/modules/cart/tests/src/FunctionalJavascript/MultipleCartFormsTest.php
+++ b/modules/cart/tests/src/FunctionalJavascript/MultipleCartFormsTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Drupal\Tests\commerce_cart\FunctionalJavascript;
+
+use Drupal\Tests\commerce\FunctionalJavascript\JavascriptTestTrait;
+use Drupal\commerce_order\Entity\Order;
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\ProductVariationType;
+use Drupal\Tests\commerce_cart\Functional\CartBrowserTestBase;
+
+/**
+ * Tests pages with multiple products rendered with add to cart forms.
+ *
+ * @group commerce
+ */
+class MultipleCartFormsTest extends CartBrowserTestBase {
+
+  use JavascriptTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    /** @var \Drupal\commerce_product\Entity\ProductVariationTypeInterface $variation_type */
+    $variation_type = ProductVariationType::load($this->variation->bundle());
+
+    $color_attributes = $this->createAttributeSet($variation_type, 'color', [
+      'red' => 'Red',
+      'blue' => 'Blue',
+    ]);
+    $size_attributes = $this->createAttributeSet($variation_type, 'size', [
+      'small' => 'Small',
+      'medium' => 'Medium',
+      'large' => 'Large',
+    ]);
+
+    // The matrix is intentionally uneven, blue / large is missing.
+    $attribute_values_matrix = [
+      ['red', 'small'],
+      ['red', 'medium'],
+      ['red', 'large'],
+      ['blue', 'small'],
+      ['blue', 'medium'],
+    ];
+
+    $price_number_matrix = [
+      1 => [
+        [1 => '1'],
+        [2 => '2'],
+        [3 => '3'],
+        [4 => '4'],
+        [5 => '5'],
+      ],
+      2 => [
+        [1 => '6'],
+        [2 => '7'],
+        [3 => '8'],
+        [4 => '9'],
+        [5 => '10'],
+      ],
+      3 => [
+        [1 => '11'],
+        [2 => '12'],
+        [3 => '13'],
+        [4 => '14'],
+        [5 => '15'],
+      ],
+      4 => [
+        [1 => '16'],
+        [2 => '17'],
+        [3 => '18'],
+        [4 => '19'],
+        [5 => '20'],
+      ],
+      5 => [
+        [1 => '21'],
+        [2 => '22'],
+        [3 => '23'],
+        [4 => '24'],
+        [5 => '25'],
+      ],
+    ];
+
+    for ($i = 1; $i < 6; $i++) {
+      // Generate products with variations off of the attributes values matrix.
+      $j = 0;
+      $variations = [];
+      foreach ($attribute_values_matrix as $key => $value) {
+        $variation = $this->createEntity('commerce_product_variation', [
+          'type' => $variation_type->id(),
+          'sku' => $this->randomMachineName(),
+          'price' => new Price($price_number_matrix[$i][$j][$j + 1], 'USD'),
+          'attribute_color' => $color_attributes[$value[0]],
+          'attribute_size' => $size_attributes[$value[1]],
+        ]);
+        $variations[] = $variation;
+        $j++;
+      }
+      if ($i == 1) {
+        $product = $this->variation->getProduct();
+        $product->setVariations($variations);
+        $product->updateOriginalvalues();
+        $product->save();
+        $this->products[] = $product;
+      }
+      else {
+        $this->products[] = $this->createEntity('commerce_product', [
+          'type' => 'default',
+          'title' => $this->randomMachineName(),
+          'stores' => [$this->store],
+          'variations' => $variations,
+        ]);
+      }
+    }
+  }
+
+  /**
+   * Tests that a page with multiple add to cart forms works properly.
+   */
+  public function testMultipleCartsOnPage() {
+    // The matrix to change values on Add to cart forms in the given offset
+    // order. Don't use Red and Small values as they are selected by default.
+    $offset_matrix = [
+      3 => ['size' => 'Large'],
+      1 => ['color' => 'Blue'],
+      0 => ['size' => 'Medium'],
+      2 => ['color' => 'Blue'],
+      4 => ['size' => 'Large'],
+    ];
+
+    foreach ($offset_matrix as $offset => $attribute) {
+      $this->drupalGet('/test-multiple-cart-forms');
+      /** @var \Behat\Mink\Element\NodeElement[] $forms */
+      $forms = $this->getSession()->getPage()->findAll('css', '.commerce-order-item-add-to-cart-form');
+      $this->assertCount(5, $forms, 'Displayed 5 Add to cart forms.');
+      $values = $this->addProductVariationToCart($forms, $offset, $attribute);
+      // Assert expected form values before and after submission.
+      $this->assertAddToCartFormValues($values);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function addProductVariationToCart(array $forms, $offset = 0, $attribute = ['size' => 'Medium']) {
+    $init = $this->getAddToCartFormValues($forms[$offset]);
+    $init['count'] = count($forms);
+    $field = array_keys($attribute)[0];
+    $label = reset($attribute);
+
+    // Change the attribute option to trigger the AJAX form reloading.
+    $forms[$offset]->selectFieldOption("purchased_entity[0][attributes][attribute_{$field}]", $label);
+    $this->waitForAjaxToFinish();
+    // Extract updated form values.
+    $forms = $this->getSession()->getPage()->findAll('css', '.commerce-order-item-add-to-cart-form');
+    $after = $this->getAddToCartFormValues($forms[$offset]);
+    $this->submitForm([], 'Add to cart', $after['form_id']);
+
+    return [
+      'init' => $init,
+      'after' => $after,
+      'offset' => $offset,
+      'field' => $field,
+      'label' => $label,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertAddToCartFormValues(array $values) {
+    $this->drupalGet('cart');
+    $cart = $this->getSession()->getPage()->find('css', '[id^="views-form-commerce-cart-form-default"]');
+    $this->assertTrue(is_object($cart), 'The Shopping cart is displayed.');
+    $cart = $this->getShoppingCartValues($cart);
+    $cart = end($cart);
+    $label = ucfirst($values['field']);
+    $init = $values['init']['attributes'][$label]['chosen'];
+    $after = $values['after']['attributes'][$label]['chosen'];
+
+    // Ensure we are on the same product where we had triggered an AJAX action.
+    $this->assertSame($values['init']['product_id'], $values['after']['product_id'], 'The product ID is the same.');
+    // Both titles must be the same.
+    $this->assertSame($cart['title'], $values['after']['title'], 'The Shopping cart title and Add to cart title are equal.');
+    // All the other values are expected being replaced by new ones.
+    $this->assertNotEquals($values['init']['form_id'], $values['after']['form_id'], 'The Add to cart form ID is changed.');
+    $this->assertNotEquals($values['init']['title'], $values['after']['title'], 'The Add to cart form title is changed.');
+    $this->assertNotEquals($values['init']['sku'], $values['after']['sku'], 'The variation SKU is changed.');
+    $this->assertNotEquals($values['init']['price'], $values['after']['price'], 'The variation price is changed.');
+    $this->assertNotEquals($init[0]['label'], $after[0]['label'], "The {$label} attribute label is changed.");
+    $this->assertNotEquals($init[0]['value'], $after[0]['value'], "The {$label} attribute value is changed.");
+    // Prices on the Shopping cart page are formatted without decimals ($99).
+    // Extract price number value to recreate object and properly compare then.
+    $cart['price'] = new Price(ltrim($cart['price'], '$'), 'USD');
+    $values['after']['price'] = new Price(ltrim($values['after']['price'], '$'), 'USD');
+    $this->assertTrue($cart['price']->equals($values['after']['price']), 'The Shopping cart price and Add to cart price are equal.');
+  }
+
+}

--- a/modules/cart/tests/src/FunctionalJavascript/MultipleCartFormsTest.php
+++ b/modules/cart/tests/src/FunctionalJavascript/MultipleCartFormsTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\commerce_cart\FunctionalJavascript;
 
 use Drupal\Tests\commerce\FunctionalJavascript\JavascriptTestTrait;
-use Drupal\commerce_order\Entity\Order;
 use Drupal\commerce_price\Price;
 use Drupal\commerce_product\Entity\ProductVariationType;
 use Drupal\Tests\commerce_cart\Functional\CartBrowserTestBase;

--- a/modules/cart/tests/src/FunctionalJavascript/MultipleCartFormsTest.php
+++ b/modules/cart/tests/src/FunctionalJavascript/MultipleCartFormsTest.php
@@ -10,6 +10,9 @@ use Drupal\Tests\commerce_cart\Functional\CartBrowserTestBase;
 /**
  * Tests pages with multiple products rendered with add to cart forms.
  *
+ * @todo The file with the same name exists in the Functional namespace and it
+ * should be decided which one to leave for this kind of test.
+ *
  * @group commerce
  */
 class MultipleCartFormsTest extends CartBrowserTestBase {

--- a/modules/product/src/Plugin/Field/FieldWidget/ProductVariationAttributesWidget.php
+++ b/modules/product/src/Plugin/Field/FieldWidget/ProductVariationAttributesWidget.php
@@ -147,9 +147,8 @@ class ProductVariationAttributesWidget extends ProductVariationWidgetBase implem
       ],
     ];
     foreach ($this->getAttributeInfo($selected_variation, $variations) as $field_name => $attribute) {
-      $id = 'edit-purchased-entity-0-attributes-attribute-' . str_replace('_', '-', $field_name) . '-' . $id;
       $element['attributes'][$field_name] = [
-        '#id' => Html::getUniqueId($id),
+        '#id' => Html::getUniqueId('edit-purchased-entity-0-attributes-' . $field_name . '-' . $id),
         '#type' => $attribute['element_type'],
         '#title' => $attribute['title'],
         '#options' => $attribute['values'],

--- a/modules/product/src/Plugin/Field/FieldWidget/ProductVariationAttributesWidget.php
+++ b/modules/product/src/Plugin/Field/FieldWidget/ProductVariationAttributesWidget.php
@@ -112,15 +112,17 @@ class ProductVariationAttributesWidget extends ProductVariationWidgetBase implem
     }
 
     // Build the full attribute form.
-    $wrapper_id = Html::getUniqueId('commerce-product-add-to-cart-form');
+    $ids = $form_state->getFormObject()->getFormInstanceIds();
+    $id = end($ids);
+    $wrapper_id = Html::getUniqueId('commerce-product-add-to-cart-form-' . $id);
     $form += [
       '#wrapper_id' => $wrapper_id,
       '#prefix' => '<div id="' . $wrapper_id . '">',
       '#suffix' => '</div>',
     ];
-    $parents = array_merge($element['#field_parents'], [$items->getName(), $delta]);
-    $user_input = (array) NestedArray::getValue($form_state->getUserInput(), $parents);
-    if (!empty($user_input)) {
+    if ($form_state->getTriggeringElement()) {
+      $parents = array_merge($element['#field_parents'], [$items->getName(), $delta]);
+      $user_input = (array) NestedArray::getValue($form_state->getUserInput(), $parents);
       $selected_variation = $this->selectVariationFromUserInput($variations, $user_input);
     }
     else {
@@ -145,7 +147,9 @@ class ProductVariationAttributesWidget extends ProductVariationWidgetBase implem
       ],
     ];
     foreach ($this->getAttributeInfo($selected_variation, $variations) as $field_name => $attribute) {
+      $id = 'edit-purchased-entity-0-attributes-attribute-' . str_replace('_', '-', $field_name) . '-' . $id;
       $element['attributes'][$field_name] = [
+        '#id' => Html::getUniqueId($id),
         '#type' => $attribute['element_type'],
         '#title' => $attribute['title'],
         '#options' => $attribute['values'],
@@ -176,6 +180,7 @@ class ProductVariationAttributesWidget extends ProductVariationWidgetBase implem
       if (!isset($element['attributes'][$field_name]['#empty_value'])) {
         $element['attributes'][$field_name]['#required'] = TRUE;
       }
+
     }
 
     return $element;


### PR DESCRIPTION
…AddToCartForm should support all purchasable entities

Works with multiple add to cart forms having different number of attributes. Also works with add to cart duplications on a page but the only deficiency is that all SKUs, titles and prices are replaced properly on all the twin carts but the attribute value is replaced just on the element which is actually triggered an ajax event. Obviously it requires a solution for this complex add to carts use case but for now it might be easily resolved by excluding the same add to cart forms on a page or just ignoring ,,the feature,, as it does not break checkout workflow in any way except UX issue.


**Important note:** if you still require multiple duplicated carts on a page you need to disable views caches on the each next view (page or block) which has the same add to cart forms as the previous one.

![noviewscaching](https://cloud.githubusercontent.com/assets/3609840/21135712/7ad9575c-c12b-11e6-9c98-b7e90da69094.png)
