### PR TITLE
Issue #2659032 by mglaman, steveoliver: Add the cache contexts for th…

### DIFF
--- a/modules/cart/src/Cache/Context/CartCacheContext.php
+++ b/modules/cart/src/Cache/Context/CartCacheContext.php
@@ -59,7 +59,11 @@ class CartCacheContext implements CacheContextInterface {
    * {@inheritdoc}
    */
   public function getCacheableMetadata() {
-    return new CacheableMetadata();
+    $metadata = new CacheableMetadata();
+    foreach ($this->cartProvider->getCarts($this->account) as $cart) {
+      $metadata->addCacheableDependency($cart);
+    }
+    return $metadata;
   }
 
 }

--- a/modules/cart/tests/src/Unit/CartCacheContextTest.php
+++ b/modules/cart/tests/src/Unit/CartCacheContextTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\commerce_cart\Unit;
 use Drupal\commerce_cart\Cache\Context\CartCacheContext;
 use Drupal\commerce_cart\CartProviderInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\Core\Render\TestCacheableDependency;
 use Drupal\Tests\UnitTestCase;
 
 /**
@@ -20,9 +21,14 @@ class CartCacheContextTest extends UnitTestCase {
     $account = $this->getMock(AccountInterface::class);
     $cartProvider = $this->getMock(CartProviderInterface::class);
     $cartProvider->expects($this->once())->method('getCartIds')->willReturn(['23', '34']);
+    $cartProvider->expects($this->once())->method('getCarts')->willReturn([
+      new TestCacheableDependency([], ['commerce_cart:23'], 0),
+      new TestCacheableDependency([], ['commerce_cart:24'], 0),
+    ]);
 
     $cartCache = new CartCacheContext($account, $cartProvider);
     $this->assertEquals('23:34', $cartCache->getContext());
+    $this->assertEquals(['commerce_cart:23', 'commerce_cart:24'], $cartCache->getCacheableMetadata()->getCacheTags());
   }
 
 }


### PR DESCRIPTION
…e cart block

@bojanz with our test coverage this can be easily tested. Such as commenting out code within `\Drupal\commerce_cart\Plugin\Block\CartBlock::getCacheTags`.