### PR TITLE
Issue #2810723: Allow order types to have no carts

### DIFF
--- a/modules/order/config/schema/commerce_order.schema.yml
+++ b/modules/order/config/schema/commerce_order.schema.yml
@@ -14,6 +14,9 @@ commerce_order.commerce_order_type.*:
     refresh_mode:
       type: string
       label: 'Order refresh mode'
+    cart_disabled:
+      type: boolean
+      label: 'Disable the cart for this order type'
     refresh_frequency:
       type: integer
       label: 'Order refresh frequency'

--- a/modules/order/src/Entity/OrderType.php
+++ b/modules/order/src/Entity/OrderType.php
@@ -39,6 +39,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *     "label",
  *     "id",
  *     "workflow",
+ *     "cart_disabled",
  *     "refresh_mode",
  *     "refresh_frequency",
  *     "sendReceipt",
@@ -74,6 +75,13 @@ class OrderType extends ConfigEntityBundleBase implements OrderTypeInterface {
    * @var string
    */
   protected $workflow;
+
+  /**
+   * Whether the cart is disabled.
+   *
+   * @var bool
+   */
+  protected $cart_disabled;
 
   /**
    * The order type refresh mode.
@@ -130,6 +138,21 @@ class OrderType extends ConfigEntityBundleBase implements OrderTypeInterface {
    */
   public function setRefreshMode($refresh_mode) {
     $this->refresh_mode = $refresh_mode;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCartMode() {
+    return $this->cart_disabled;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCartMode($cart_disabled) {
+    $this->cart_disabled = $cart_disabled;
     return $this;
   }
 

--- a/modules/order/src/Entity/OrderTypeInterface.php
+++ b/modules/order/src/Entity/OrderTypeInterface.php
@@ -34,6 +34,27 @@ interface OrderTypeInterface extends ConfigEntityInterface {
   public function setWorkflowId($workflow_id);
 
   /**
+   * Gets the order type's cart mode.
+   *
+   * Used by the checkout process to optionally skip the cart.
+   *
+   * @return boolean
+   *   Is the cart disabled.
+   */
+  public function getCartMode();
+
+  /**
+   * Sets whether the cart is disabled for the order type.
+   *
+   * Used by the checkout process to optionally skip the cart.
+   *
+   * @param boolean $cart_disabled
+   *    Is the cart disabled.
+   * @return $this
+   */
+  public function setCartMode($cart_disabled);
+
+  /**
    * Gets the order type's refresh mode.
    *
    * Used by the order refresh process.

--- a/modules/order/src/Form/OrderTypeForm.php
+++ b/modules/order/src/Form/OrderTypeForm.php
@@ -48,6 +48,23 @@ class OrderTypeForm extends BundleEntityFormBase {
       '#description' => $this->t('Used by all orders of this type.'),
     ];
 
+    $form['cart'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Checkout Mode'),
+      '#weight' => 5,
+      '#open' => TRUE,
+      '#collapsible' => TRUE,
+      '#tree' => FALSE,
+    ];
+    $form['cart']['cart_disabled'] = [
+      '#markup' => '<p>' . $this->t('These settings let you control whether to disable the cart for this specific order type.') . '</p>',
+    ];
+    $form['cart']['cart_disabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable the cart for this order'),
+      '#default_value' => ($order_type->isNew()) ? FALSE : $order_type->getCartMode(),
+    ];
+
     $form['refresh'] = [
       '#type' => 'details',
       '#title' => $this->t('Order refresh'),


### PR DESCRIPTION
Started looking at the more generic way to disable the cart (and subsequently the add to cart message for straight to checkout) 