### PR TITLE
Updating Workflow, adding new capture_pending state for bank transfers.

### DIFF
--- a/modules/payment/commerce_payment.workflows.yml
+++ b/modules/payment/commerce_payment.workflows.yml
@@ -11,6 +11,8 @@ payment_default:
       label: 'Authorization (Voided)'
     authorization_expired:
       label: 'Authorization (Expired)'
+    capture_pending:
+      label: 'Capture (Pending)'
     capture_completed:
       label: 'Capture (Completed)'
     capture_partially_refunded:
@@ -35,6 +37,10 @@ payment_default:
     authorize_capture:
       label: 'Authorize and capture payment'
       from: [new]
+      to: capture_completed
+    capture_pending:
+      label: 'Capture Pending'
+      from: [authorization]
       to: capture_completed
     capture:
       label: 'Capture payment'


### PR DESCRIPTION
This PR adds in a new workflow state, capture_pending.  The idea is that some payment methods like Bank transfers may take a while to complete, so we should have a state that payments can sit in while we wait on a response from the processor. This was based on a brief conversation on IRC with @bojanz 