### PR TITLE
Issue #2831955: Add available_currencies settings and validations to commerce_price field

### DIFF
--- a/modules/price/src/Element/Price.php
+++ b/modules/price/src/Element/Price.php
@@ -18,6 +18,7 @@ use Drupal\Core\Render\Element\FormElement;
  *   '#size' => 60,
  *   '#maxlength' => 128,
  *   '#required' => TRUE,
+ *   '#available_currencies' => ['USD', 'EUR'],
  * ];
  * @endcode
  *
@@ -31,6 +32,9 @@ class Price extends FormElement {
   public function getInfo() {
     $class = get_class($this);
     return [
+      // List of currencies codes. If empty, all currencies will be available.
+      '#available_currencies' => [],
+
       '#size' => 10,
       '#maxlength' => 128,
       '#default_value' => NULL,
@@ -79,6 +83,13 @@ class Price extends FormElement {
     /** @var \Drupal\commerce_price\Entity\CurrencyInterface[] $currencies */
     $currencies = $currency_storage->loadMultiple();
     $currency_codes = array_keys($currencies);
+
+    // Keep only available currencies.
+    $available_currencies = $element['#available_currencies'];
+    if (isset($available_currencies) && !empty($available_currencies)) {
+      $currency_codes = array_intersect($currency_codes, $available_currencies);
+    }
+
     // Stop rendering if there are no currencies available.
     if (empty($currency_codes)) {
       return $element;

--- a/modules/price/src/Element/Price.php
+++ b/modules/price/src/Element/Price.php
@@ -83,13 +83,11 @@ class Price extends FormElement {
     /** @var \Drupal\commerce_price\Entity\CurrencyInterface[] $currencies */
     $currencies = $currency_storage->loadMultiple();
     $currency_codes = array_keys($currencies);
-
     // Keep only available currencies.
     $available_currencies = $element['#available_currencies'];
     if (isset($available_currencies) && !empty($available_currencies)) {
       $currency_codes = array_intersect($currency_codes, $available_currencies);
     }
-
     // Stop rendering if there are no currencies available.
     if (empty($currency_codes)) {
       return $element;

--- a/modules/price/src/Plugin/Field/FieldType/PriceItem.php
+++ b/modules/price/src/Plugin/Field/FieldType/PriceItem.php
@@ -82,7 +82,7 @@ class PriceItem extends FieldItemBase {
 
     $currencies_options = [];
     foreach ($currencies as $currency) {
-      $currencies_options[] = $currency->getCurrencyCode();
+      $currencies_options[$currency->getCurrencyCode()] = $currency->getCurrencyCode();
     }
 
     $element = [];
@@ -114,7 +114,7 @@ class PriceItem extends FieldItemBase {
         $currencies = \Drupal::entityTypeManager()->getStorage('commerce_currency')->loadMultiple();
 
         foreach ($currencies as $currency) {
-          $available_currencies[] = $currency->getCurrencyCode();
+          $available_currencies[$currency->getCurrencyCode()] = $currency->getCurrencyCode();
         }
       }
       static::$availableCurrencies[$definition_id] = $available_currencies;

--- a/modules/price/src/Plugin/Field/FieldType/PriceItem.php
+++ b/modules/price/src/Plugin/Field/FieldType/PriceItem.php
@@ -70,8 +70,8 @@ class PriceItem extends FieldItemBase {
    */
   public static function defaultFieldSettings() {
     return [
-        'available_currencies' => [],
-      ] + parent::defaultFieldSettings();
+      'available_currencies' => [],
+    ] + parent::defaultFieldSettings();
   }
 
   /**

--- a/modules/price/src/Plugin/Field/FieldWidget/PriceDefaultWidget.php
+++ b/modules/price/src/Plugin/Field/FieldWidget/PriceDefaultWidget.php
@@ -28,6 +28,10 @@ class PriceDefaultWidget extends WidgetBase {
       $element['#default_value'] = $items[$delta]->toPrice()->toArray();
     }
 
+    $available_currencies = $items[$delta]->getAvailableCurrencies();
+
+    $element['#available_currencies'] = $available_currencies;
+
     return $element;
   }
 

--- a/modules/price/src/Plugin/Validation/Constraint/CurrencyConstraint.php
+++ b/modules/price/src/Plugin/Validation/Constraint/CurrencyConstraint.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\commerce_price\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Currency constraint.
+ *
+ * @Constraint(
+ *   id = "Currency",
+ *   label = @Translation("Currency", context = "Validation"),
+ *   type = { "commerce_price" }
+ * )
+ */
+class CurrencyConstraint extends Constraint {
+
+  public $availableCurrencies = [];
+  public $invalidMessage = 'The Currency %value is not valid.';
+  public $notAvailableMessage = 'The Currency %value is not available.';
+
+}

--- a/modules/price/src/Plugin/Validation/Constraint/CurrencyConstraintValidator.php
+++ b/modules/price/src/Plugin/Validation/Constraint/CurrencyConstraintValidator.php
@@ -63,11 +63,11 @@ class CurrencyConstraintValidator extends ConstraintValidator implements Contain
     }
 
     $available_currencies = $constraint->availableCurrencies;
-     if (!empty($available_currencies) && !in_array($currency_code, $available_currencies)) {
-       $this->context->buildViolation($constraint->notAvailableMessage)
-          ->atPath('currency_code')
-          ->setParameter('%value', $this->formatValue($currency_code))
-          ->addViolation();
+    if (!empty($available_currencies) && !in_array($currency_code, $available_currencies)) {
+      $this->context->buildViolation($constraint->notAvailableMessage)
+        ->atPath('currency_code')
+        ->setParameter('%value', $this->formatValue($currency_code))
+        ->addViolation();
     }
   }
 

--- a/modules/price/src/Plugin/Validation/Constraint/CurrencyConstraintValidator.php
+++ b/modules/price/src/Plugin/Validation/Constraint/CurrencyConstraintValidator.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\commerce_price\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\commerce_price\Plugin\Field\FieldType\PriceItem;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Validates the currency constraint.
+ */
+class CurrencyConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * Constructs a new CurrencyConstraintValidator object.
+   *
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entityManager
+   *   The entity manager.
+   */
+  public function __construct(EntityManagerInterface $entityManager) {
+    $this->entityManager = $entityManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('entity.manager'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($value, Constraint $constraint) {
+    if (!($value instanceof PriceItem)) {
+      throw new UnexpectedTypeException($value, 'PriceItem');
+    }
+
+    $price_item = $value;
+    $currency_code = $price_item->get('currency_code')->getValue();
+    if ($currency_code === NULL || $currency_code === '') {
+      return;
+    }
+
+    $currencies = $this->entityManager->getStorage('commerce_currency')->loadMultiple();
+    if (!isset($currencies[$currency_code])) {
+      $this->context->buildViolation($constraint->invalidMessage)
+        ->atPath('currency_code')
+        ->setParameter('%value', $this->formatValue($currency_code))
+        ->addViolation();
+      return;
+    }
+
+    $available_currencies = $constraint->availableCurrencies;
+     if (!empty($available_currencies) && !in_array($currency_code, $available_currencies)) {
+       $this->context->buildViolation($constraint->notAvailableMessage)
+          ->atPath('currency_code')
+          ->setParameter('%value', $this->formatValue($currency_code))
+          ->addViolation();
+    }
+  }
+
+}

--- a/modules/price/tests/modules/commerce_price_test/commerce_price_test.routing.yml
+++ b/modules/price/tests/modules/commerce_price_test/commerce_price_test.routing.yml
@@ -13,3 +13,11 @@ commerce_price_test.price_test_form:
     _title: 'Price test form'
   requirements:
     _access: 'TRUE'
+
+commerce_price_available_currencies_test.price_test_form:
+  path: '/commerce_price_test/price_available_currencies_test_form'
+  defaults:
+    _form: '\Drupal\commerce_price_test\Form\PriceAvailableCurrenciesTestForm'
+    _title: 'Price available currencies test form'
+  requirements:
+    _access: 'TRUE'

--- a/modules/price/tests/modules/commerce_price_test/src/Form/PriceAvailableCurrenciesTestForm.php
+++ b/modules/price/tests/modules/commerce_price_test/src/Form/PriceAvailableCurrenciesTestForm.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\commerce_price_test\Form;
+
+use Drupal\commerce_price\Price;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+class PriceAvailableCurrenciesTestForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'commerce_price_available_currencies_element_test_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['amount'] = [
+      '#type' => 'commerce_price',
+      '#title' => $this->t('Amount'),
+      '#default_value' => ['number' => '99.99', 'currency_code' => 'USD'],
+      '#required' => TRUE,
+      '#available_currencies' => ['USD', 'EUR'],
+    ];
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Submit'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Create a Price to ensure the values are valid.
+    $value = $form_state->getValue('amount');
+    $price = new Price($value['number'], $value['currency_code']);
+    drupal_set_message(t('The number is "@number" and the currency code is "@currency_code".', [
+      '@number' => $price->getNumber(),
+      '@currency_code' => $price->getCurrencyCode(),
+    ]));
+  }
+
+}

--- a/modules/price/tests/src/Functional/PriceElementTest.php
+++ b/modules/price/tests/src/Functional/PriceElementTest.php
@@ -77,4 +77,45 @@ class PriceElementTest extends CommerceBrowserTestBase {
     $this->assertSession()->pageTextContains('The number is "10.99" and the currency code is "EUR".');
   }
 
+  /**
+   * Tests the element with available currencies.
+   */
+  public function testAvailableCurrency() {
+    $this->container->get('commerce_price.currency_importer')->import('EUR');
+    $this->container->get('commerce_price.currency_importer')->import('CHF');
+
+    $this->drupalGet('/commerce_price_test/price_available_currencies_test_form');
+    $this->assertSession()->fieldExists('amount[number]');
+    $this->assertSession()->fieldExists('amount[currency_code]');
+    // Default value.
+    $this->assertSession()->fieldValueEquals('amount[number]', '99.99');
+    $this->assertSession()->optionExists('amount[currency_code]', 'USD');
+    $element = $this->assertSession()->optionExists('amount[currency_code]', 'USD');
+    $this->assertNotEmpty($element->isSelected());
+
+    // Check options exist depending of #available_currencies settings.
+    $this->assertSession()->optionExists('amount[currency_code]', 'EUR');
+    $this->assertSession()->optionNotExists('amount[currency_code]', 'CHF');
+
+    // Invalid submit with unavailable currency.
+    try {
+      $edit = [
+        'amount[number]' => '99.99',
+        'amount[currency_code]' => 'CHF',
+      ];
+      $this->submitForm($edit, 'Submit');
+    }
+    catch (\InvalidArgumentException $e) {
+      $this->assertEquals($e->getMessage(), 'Input "amount[currency_code]" cannot take "CHF" as a value (possible values: EUR, USD).');
+    }
+
+    // Valid submit.
+    $edit = [
+      'amount[number]' => '10.99',
+      'amount[currency_code]' => 'EUR',
+    ];
+    $this->submitForm($edit, 'Submit');
+    $this->assertSession()->pageTextContains('The number is "10.99" and the currency code is "EUR".');
+  }
+
 }


### PR DESCRIPTION
I'm working now on writing tests for this.