### PR TITLE
Issue #2849342: Show Order activity log entries in chronological order.

### DIFF
--- a/modules/log/commerce_log.post_update.php
+++ b/modules/log/commerce_log.post_update.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for Log.
+ */
+
+/**
+ * Revert Order activity view to fix log entry order.
+ */
+function commerce_log_post_update_1() {
+  /** @var \Drupal\commerce\Config\ConfigUpdaterInterface $config_updater */
+  $config_updater = \Drupal::service('commerce.config_updater');
+
+  $views = [
+    'views.view.commerce_activity',
+  ];
+  $result = $config_updater->revert($views, FALSE);
+
+  $success_results = $result->getSucceeded();
+  $failure_results = $result->getFailed();
+  if ($success_results) {
+    $message = t('Succeeded:') . '<br>';
+    foreach ($success_results as $success_message) {
+      $message .= $success_message . '<br>';
+    }
+    $message .= '<br>';
+  }
+  if ($failure_results) {
+    $message .= t('Failed:') . '<br>';
+    foreach ($failure_results as $failure_message) {
+      $message .= $failure_message . '<br>';
+    }
+  }
+
+  return $message;
+}

--- a/modules/log/config/install/views.view.commerce_activity.yml
+++ b/modules/log/config/install/views.view.commerce_activity.yml
@@ -245,7 +245,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: DESC
+          order: ASC
           exposed: false
           expose:
             label: ''
@@ -260,7 +260,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: DESC
+          order: ASC
           exposed: false
           expose:
             label: ''


### PR DESCRIPTION
See https://www.drupal.org/node/2849342.