### PR TITLE
Issue #2849502: Remove form_state object reference

### DIFF
--- a/modules/price/src/Form/CurrencyForm.php
+++ b/modules/price/src/Form/CurrencyForm.php
@@ -105,7 +105,7 @@ class CurrencyForm extends EntityForm {
   /**
    * Validates the currency code.
    */
-  public function validateCurrencyCode(array $element, FormStateInterface &$form_state, array $form) {
+  public function validateCurrencyCode(array $element, FormStateInterface $form_state, array $form) {
     $currency = $this->getEntity();
     $currency_code = $element['#value'];
     if (!preg_match('/^[A-Z]{3}$/', $currency_code)) {
@@ -122,7 +122,7 @@ class CurrencyForm extends EntityForm {
   /**
    * Validates the numeric code.
    */
-  public function validateNumericCode(array $element, FormStateInterface &$form_state, array $form) {
+  public function validateNumericCode(array $element, FormStateInterface $form_state, array $form) {
     $currency = $this->getEntity();
     $numeric_code = $element['#value'];
     if ($numeric_code && !preg_match('/^\d{3}$/i', $numeric_code)) {

--- a/src/Element/PluginSelect.php
+++ b/src/Element/PluginSelect.php
@@ -136,7 +136,7 @@ class PluginSelect extends CommerceElementBase {
   /**
    * Ajax callback.
    */
-  public static function pluginFormAjax(&$form, FormStateInterface &$form_state, Request $request) {
+  public static function pluginFormAjax(&$form, FormStateInterface $form_state, Request $request) {
     $triggering_element = $form_state->getTriggeringElement();
     while (!isset($triggering_element['#ajax_array_parents'])) {
       array_pop($triggering_element['#array_parents']);


### PR DESCRIPTION
Since form_state is an object, no more needed to explicitly define it as reference in function declaration see https://www.drupal.org/node/2849502