### PR TITLE
Issue 2855587: Investigate why DrupalCI fails on checkout based Funct…

### DIFF
--- a/.travis-script-simpletest-js.sh
+++ b/.travis-script-simpletest-js.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# @file
+# Simple script to run the tests via travis-ci.
+
+set -e $DRUPAL_TI_DEBUG
+
+export ARGS=( $DRUPAL_TI_SIMPLETEST_JS_ARGS )
+
+if [ -n "$DRUPAL_TI_SIMPLETEST_GROUP" ]
+then
+        ARGS=( "${ARGS[@]}" "$DRUPAL_TI_SIMPLETEST_GROUP" )
+fi
+
+
+cd "$DRUPAL_TI_DRUPAL_DIR"
+{ php "$DRUPAL_TI_SIMPLETEST_FILE" --php $(which php) "${ARGS[@]}" || echo "1 fails"; } | tee /tmp/simpletest-result.txt
+
+egrep -i "([1-9]+ fail[s]?)|(Fatal error)|([1-9]+ exception[s]?)" /tmp/simpletest-result.txt && exit 1
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,8 @@ env:
     - DRUPAL_TI_WEBSERVER_PORT="8080"
 
     # Simpletest specific commandline arguments, the DRUPAL_TI_SIMPLETEST_GROUP is appended at the end.
-    - DRUPAL_TI_SIMPLETEST_ARGS="--verbose --color --concurrency 4 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT --types Simpletest"
+    - DRUPAL_TI_SIMPLETEST_ARGS="--verbose --color --concurrency 15 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT --types Simpletest,PHPUnit-Unit,PHPUnit-Kernel,PHPUnit-Functional"
+    - DRUPAL_TI_SIMPLETEST_JS_ARGS="--verbose --color --concurrency 1 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT --types PHPUnit-FunctionalJavascript"
 
     # === Behat specific variables.
     # This is relative to $TRAVIS_BUILD_DIR
@@ -88,7 +89,7 @@ env:
   matrix:
     # [[[ SELECT ANY OR MORE OPTIONS ]]]
     #- DRUPAL_TI_RUNNERS="phpunit"
-    - DRUPAL_TI_RUNNERS="phpunit-core"
+    - DRUPAL_TI_RUNNERS="simpletest"
     #- DRUPAL_TI_RUNNERS="behat"
     #- DRUPAL_TI_RUNNERS="phpunit simpletest behat"
 
@@ -123,11 +124,9 @@ before_script:
   - drupal-ti before_script
 
 script:
-  - phpcs --standard=phpcs.xml src -s
-  - phpcs --standard=phpcs.xml modules -s
-  - phpcs --standard=phpcs.xml tests -s
-  - phpcs --standard=phpcs.xml commerce.module
+  - phpcs --standard=phpcs.xml .
   - drupal-ti script
+  - drupal-ti --include ".travis-script-simpletest-js.sh"
 
 after_script:
   - drupal-ti after_script

--- a/modules/payment/tests/src/Functional/PaymentCheckoutOffsiteRedirectTest.php
+++ b/modules/payment/tests/src/Functional/PaymentCheckoutOffsiteRedirectTest.php
@@ -81,7 +81,7 @@ class PaymentCheckoutOffsiteRedirectTest extends CommerceBrowserTestBase {
    * Tests the off-site redirect using the POST redirect method.
    */
   public function testCheckoutWithOffsiteRedirectPost() {
-    $this->drupalGet($this->product->toUrl()->toString());
+    $this->drupalGet($this->product->toUrl());
     $this->submitForm([], 'Add to cart');
     $cart_link = $this->getSession()->getPage()->findLink('your cart');
     $cart_link->click();
@@ -124,7 +124,7 @@ class PaymentCheckoutOffsiteRedirectTest extends CommerceBrowserTestBase {
     ]);
     $payment_gateway->save();
 
-    $this->drupalGet($this->product->toUrl()->toString());
+    $this->drupalGet($this->product->toUrl());
     $this->submitForm([], 'Add to cart');
     $cart_link = $this->getSession()->getPage()->findLink('your cart');
     $cart_link->click();

--- a/modules/payment/tests/src/Functional/PaymentCheckoutTest.php
+++ b/modules/payment/tests/src/Functional/PaymentCheckoutTest.php
@@ -6,6 +6,7 @@ use Drupal\commerce_checkout\Entity\CheckoutFlow;
 use Drupal\commerce_order\Entity\Order;
 use Drupal\commerce_payment\Entity\Payment;
 use Drupal\commerce_payment\Entity\PaymentGateway;
+use Drupal\Core\Url;
 use Drupal\Tests\commerce\Functional\CommerceBrowserTestBase;
 
 /**
@@ -97,13 +98,13 @@ class PaymentCheckoutTest extends CommerceBrowserTestBase {
    * Tests than an order can go through checkout steps.
    */
   public function testCheckoutWithPayment() {
-    $this->drupalGet($this->product->toUrl()->toString());
+    $this->drupalGet($this->product->toUrl());
     $this->submitForm([], 'Add to cart');
     // The order's payment method should be available and default.
     $order = Order::load(1);
     $order->payment_method = $this->paymentMethod;
     $order->save();
-    $this->drupalGet('checkout/1');
+    $this->drupalGet(Url::fromRoute('commerce_checkout.form', ['commerce_order' => 1]));
     $this->assertSession()->pageTextContains('Order Summary');
     $radio_button = $this->getSession()->getPage()->findField('Visa ending in 9999');
     $this->assertNotNull($radio_button);
@@ -157,7 +158,7 @@ class PaymentCheckoutTest extends CommerceBrowserTestBase {
    * Tests that a declined payment does not complete checkout.
    */
   public function testDeclineStopsCheckout() {
-    $this->drupalGet($this->product->toUrl()->toString());
+    $this->drupalGet($this->product->toUrl());
     $this->submitForm([], 'Add to cart');
     $cart_link = $this->getSession()->getPage()->findLink('your cart');
     $cart_link->click();
@@ -204,7 +205,7 @@ class PaymentCheckoutTest extends CommerceBrowserTestBase {
     $plugin->setConfiguration($configuration);
     $checkout_flow->save();
 
-    $this->drupalGet($this->product->toUrl()->toString());
+    $this->drupalGet($this->product->toUrl());
     $this->submitForm([], 'Add to cart');
     $cart_link = $this->getSession()->getPage()->findLink('your cart');
     $cart_link->click();


### PR DESCRIPTION
…ional and FunctionalJavascript tests

BrowserTestBase->drupalGet() takes as the first argument relative path or absolute path or Url object.

But seems that relative path fails in some environments to be resolved to proper url.