### PR TITLE
2862339 - Add event listener to payments

### DIFF
--- a/modules/payment/src/Event/PaymentEvent.php
+++ b/modules/payment/src/Event/PaymentEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\commerce_payment\Event;
+
+use Drupal\commerce_payment\Entity\PaymentInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Defines the payment event.
+ *
+ * @see \Drupal\commerce_payment\Event\PaymentEvents
+ */
+class PaymentEvent extends Event {
+
+  /**
+   * The payment.
+   *
+   * @var \Drupal\commerce_payment\Entity\PaymentInterface
+   */
+  protected $payment;
+
+  /**
+   * Constructs a new Paymentevent.
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentInterface $payment
+   *   The payment.
+   */
+  public function __construct(PaymentInterface $payment) {
+    $this->payment = $payment;
+  }
+
+  /**
+   * Gets the payment.
+   *
+   * @return \Drupal\commerce_payment\Entity\PaymentInterface
+   *   Gets the payment.
+   */
+  public function getOrder() {
+    return $this->payment;
+  }
+
+}

--- a/modules/payment/src/Event/PaymentEvents.php
+++ b/modules/payment/src/Event/PaymentEvents.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\commerce_payment\Event;
+
+final class PaymentEvents {
+
+  /**
+   * Name of the event fired after loading an payment.
+   *
+   * @Event
+   *
+   * @see \Drupal\commerce_payment\Event\PaymentEvent
+   */
+  const PAYMENT_LOAD = 'commerce_payment.commerce_payment.load';
+
+  /**
+   * Name of the event fired after creating a new payment.
+   *
+   * Fired before the payment is saved.
+   *
+   * @Event
+   *
+   * @see \Drupal\commerce_payment\Event\PaymentEvent
+   */
+  const PAYMENT_CREATE = 'commerce_payment.commerce_payment.create';
+
+  /**
+   * Name of the event fired before saving an payment.
+   *
+   * @Event
+   *
+   * @see \Drupal\commerce_payment\Event\PaymentEvent
+   */
+  const PAYMENT_PRESAVE = 'commerce_payment.commerce_payment.presave';
+
+  /**
+   * Name of the event fired after saving a new payment.
+   *
+   * @Event
+   *
+   * @see \Drupal\commerce_payment\Event\PaymentEvent
+   */
+  const PAYMENT_INSERT = 'commerce_payment.commerce_payment.insert';
+
+  /**
+   * Name of the event fired after saving an existing payment.
+   *
+   * @Event
+   *
+   * @see \Drupal\commerce_payment\Event\PaymentEvent
+   */
+  const PAYMENT_UPDATE = 'commerce_payment.commerce_payment.update';
+
+  /**
+   * Name of the event fired before deleting an payment.
+   *
+   * @Event
+   *
+   * @see \Drupal\commerce_payment\Event\PaymentEvent
+   */
+  const PAYMENT_PREDELETE = 'commerce_payment.commerce_payment.predelete';
+
+  /**
+   * Name of the event fired after deleting an payment.
+   *
+   * @Event
+   *
+   * @see \Drupal\commerce_payment\Event\PaymentEvent
+   */
+  const PAYMENT_DELETE = 'commerce_payment.commerce_payment.delete';
+
+}

--- a/modules/payment/src/PaymentStorage.php
+++ b/modules/payment/src/PaymentStorage.php
@@ -4,6 +4,7 @@ namespace Drupal\commerce_payment;
 
 use Drupal\commerce\CommerceContentEntityStorage;
 use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_payment\Event\PaymentEvent;
 use Drupal\Core\Entity\EntityStorageException;
 
 /**
@@ -43,7 +44,13 @@ class PaymentStorage extends CommerceContentEntityStorage implements PaymentStor
       $values['type'] = $payment_type->getPluginId();
     }
 
-    return parent::doCreate($values);
+    $payment = parent::doCreate($values);
+
+    // Notify other modules.
+    $event = new PaymentEvent($payment);
+    $this->eventDispatcher->dispatch('commerce_payment.commerce_payment.create', $event);
+
+    return $payment;
   }
 
 }

--- a/modules/payment/tests/modules/payment_events_test/payment_events_test.info.yml
+++ b/modules/payment/tests/modules/payment_events_test/payment_events_test.info.yml
@@ -1,0 +1,5 @@
+name: 'Configuration events test'
+type: module
+package: Testing
+version: VERSION
+core: 8.x

--- a/modules/payment/tests/modules/payment_events_test/payment_events_test.services.yml
+++ b/modules/payment/tests/modules/payment_events_test/payment_events_test.services.yml
@@ -1,0 +1,6 @@
+services:
+  payment_events_test.event_subscriber:
+    class: Drupal\payment_events_test\EventSubscriber
+    arguments: ['@state']
+    tags:
+      - { name: event_subscriber }

--- a/modules/payment/tests/modules/payment_events_test/src/EventSubscriber.php
+++ b/modules/payment/tests/modules/payment_events_test/src/EventSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\payment_events_test;
+
+
+use Drupal\commerce_payment\Event\PaymentEvent;
+use Drupal\commerce_payment\Event\PaymentEvents;
+use Drupal\Core\State\StateInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class EventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The state key value store.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Constructs the Event Subscriber object.
+   *
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state key value store.
+   */
+  public function __construct(StateInterface $state) {
+    $this->state = $state;
+  }
+
+  /**
+   * Reacts to payment event.
+   *
+   * @param \Drupal\commerce_payment\Event\PaymentEvent $event
+   *   The payment event.
+   * @param $name
+   *   The name of the event.
+   */
+  public function paymentEvent(PaymentEvent $event, $name) {
+    $this->state->set('payment_events_test.event', [
+      'event_name' => $name,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[PaymentEvents::PAYMENT_LOAD][] = ['paymentEvent'];
+    $events[PaymentEvents::PAYMENT_CREATE][] = ['paymentEvent'];
+    return $events;
+  }
+
+}

--- a/modules/payment/tests/src/Kernel/PaymentEventsTest.php
+++ b/modules/payment/tests/src/Kernel/PaymentEventsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\Tests\commerce_payment\Kernel;
+
+use Drupal\commerce_order\Entity\OrderItemType;
+use Drupal\commerce_payment\Entity\Payment;
+use Drupal\commerce_payment\Entity\PaymentGateway;
+use Drupal\commerce_payment\Entity\PaymentMethod;
+use Drupal\Tests\commerce\Kernel\CommerceKernelTestBase;
+
+/**
+ * Tests the payment events.
+ *
+ * @group commerce
+ */
+class PaymentEventsTest extends CommerceKernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'address',
+    'entity_reference_revisions',
+    'profile',
+    'state_machine',
+    'commerce_product',
+    'commerce_order',
+    'commerce_payment',
+    'commerce_payment_example',
+    'payment_events_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('profile');
+    $this->installEntitySchema('commerce_order');
+    $this->installEntitySchema('commerce_order_item');
+    $this->installEntitySchema('commerce_payment');
+    $this->installEntitySchema('commerce_payment_method');
+    $this->installConfig('commerce_order');
+    $this->installConfig('commerce_payment');
+
+    // An order item type that doesn't need a purchasable entity, for simplicity.
+    OrderItemType::create([
+      'id' => 'test',
+      'label' => 'Test',
+      'orderType' => 'default',
+    ])->save();
+
+    $payment_gateway = PaymentGateway::create([
+      'id' => 'example',
+      'label' => 'Example',
+      'plugin' => 'example_onsite',
+    ]);
+    $payment_gateway->save();
+
+    $user = $this->createUser();
+
+    /** @var \Drupal\commerce_payment\Entity\PaymentMethodInterface $payment_method */
+    $payment_method_active = PaymentMethod::create([
+      'type' => 'credit_card',
+      'payment_gateway' => 'example',
+      // Thu, 16 Jan 2020.
+      'expires' => '1579132800',
+      'uid' => $user->id(),
+    ]);
+    $payment_method_active->save();
+  }
+
+  /**
+   * Tests the basic payment events.
+   */
+  public function testPaymentEvents() {
+    // Create a dummy payment.
+    $payment = Payment::create([
+      'payment_gateway' => 'example',
+      'payment_method' => 'credit_card',
+      'remote_id' => '123456',
+      'amount' => [
+        'number' => '39.99',
+        'currency_code' => 'USD',
+      ],
+      'state' => 'capture_completed',
+      'test' => TRUE,
+    ]);
+    $payment->save();
+    $payment = $this->reloadEntity($payment);
+
+    // Check the create event.
+    $event_recorder = \Drupal::state()->get('payment_events_test.event', FALSE);
+    $this->assertEquals('commerce_payment.commerce_payment.create', $event_recorder['event_name']);
+
+    // Reload the payment.
+    Payment::load($payment->id());
+
+    // Check the load event.
+    $event_recorder = \Drupal::state()->get('payment_events_test.event', FALSE);
+    $this->assertEquals('commerce_payment.commerce_payment.load', $event_recorder['event_name']);
+  }
+
+}


### PR DESCRIPTION
@bojanz I did actually provide a test for the following reason:
Even if we "assume" that the default behavior of the dispatcher would work, we will never have coverage for this functionality at all, leaving that file uncovered.

When I created the basic test for the Create event, everything went fine.

When I added the load event, it broke, I checked if ORDER_LOAD was ever called somewhere in the code and it is not, leaving me with 2 questions:

1. I think it is called dynamically, but I am not sure in what way
2. I really think it deserves full coverage for all the events, because now we can never say for sure that it actually works.

