### PR TITLE
Don't compare years greater than as string

### DIFF
--- a/modules/tax/src/Plugin/Commerce/TaxType/EuropeanUnionVat.php
+++ b/modules/tax/src/Plugin/Commerce/TaxType/EuropeanUnionVat.php
@@ -80,7 +80,7 @@ class EuropeanUnionVat extends LocalTaxTypeBase {
     // to Germany needs to have German VAT applied.
     $taxable_type = $this->getTaxableType($order_item);
     $year = $this->getCalculationDate($order)->format('Y');
-    $is_digital = $taxable_type == TaxableType::DIGITAL_GOODS && $year >= '2015';
+    $is_digital = $taxable_type == TaxableType::DIGITAL_GOODS && $year >= 2015;
     $resolved_zones = [];
     if (empty($store_zones) && !empty($store_registration_zones)) {
       // The store is not in the EU but is registered to collect VAT.


### PR DESCRIPTION
> Since january 1st 2015 all digital goods sold to EU customers must use the customer zone. For example, an ebook sold to Germany needs to have German VAT applied.

The date returned by `format('Y')` should be an integer which would make php change 2015 into an integer but it's a bit weird not to just do that ourselves.