### PR TITLE
Issue #2890670: The OrderSummary pane should skip invalid views

### DIFF
--- a/modules/checkout/src/Plugin/Commerce/CheckoutPane/OrderSummary.php
+++ b/modules/checkout/src/Plugin/Commerce/CheckoutPane/OrderSummary.php
@@ -30,7 +30,9 @@ class OrderSummary extends CheckoutPaneBase implements CheckoutPaneInterface {
    */
   public function buildConfigurationSummary() {
     $view_storage = $this->entityTypeManager->getStorage('view');
-    $view = $view_storage->load($this->configuration['view']);
+    if (!$view = $view_storage->load($this->configuration['view'])) {
+      return '';
+    }
     $summary = $this->t('View: @view', ['@view' => $view->label()]);
 
     return $summary;


### PR DESCRIPTION
I install commerce 2.x from existing Drupal thanks to composer as defined in documentation.
So i have no bundles defined yet, everything has to be created (and dependencies are very numerous and painful).

I need a checkout flow bundle to be able to create product bundle, order bundle etc.

So i go to checkout flow configuration, fill fields and click on submit button.
Results is
`Error: Call to a member function label() on null in Drupal\commerce_checkout\Plugin\Commerce\CheckoutPane\OrderSummary->buildConfigurationSummary() (line 34 of modules/contrib/commerce/modules/checkout/src/Plugin/Commerce/CheckoutPane/OrderSummary.php)
`

Checkout flow bundle is still created.

See https://www.drupal.org/node/2890670