### PR TITLE
Travis CI: Define distribution for builds to Ubuntu Precise.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ language: php
 
 sudo: false
 
+dist: precise
+
 php:
   - 7
   - 5.6


### PR DESCRIPTION
As Travis have changed the default distribution for builds to Ubuntu Trusty 14.04 (see https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default), CI will fail on forks unless distribution for builds set to Precise.

Error on Trusty (comes with Phantom JS 2.1.1 by default):
phantomjs: error while loading shared libraries: libicui18n.so.48: cannot open shared object file: No such file or directory

The command "phantomjs --version" failed and exited with 127 during .