### PR TITLE
Issue #2894792: Add Adjustment:getPercentage()

### DIFF
--- a/modules/order/src/Adjustment.php
+++ b/modules/order/src/Adjustment.php
@@ -50,7 +50,7 @@ final class Adjustment {
   /**
    * The adjustment percentage.
    *
-   * @var float
+   * @var string
    */
   protected $percentage;
 
@@ -130,7 +130,7 @@ final class Adjustment {
   /**
    * Gets the adjustment percentage.
    *
-   * @return float|null
+   * @return string|null
    *   The adjustment percentage or NULL if not available.
    */
   public function getPercentage() {

--- a/modules/order/src/Adjustment.php
+++ b/modules/order/src/Adjustment.php
@@ -48,6 +48,13 @@ final class Adjustment {
   protected $included = FALSE;
 
   /**
+   * The adjustment percentage.
+   *
+   * @var float
+   */
+  protected $percentage;
+
+  /**
    * Constructs a new Adjustment object.
    *
    * @param array $definition
@@ -75,6 +82,9 @@ final class Adjustment {
       $this->sourceId = $definition['source_id'];
     }
     $this->included = !empty($definition['included']);
+    if (!empty($definition['percentage'])) {
+      $this->percentage = $definition['percentage'];
+    }
   }
 
   /**
@@ -115,6 +125,16 @@ final class Adjustment {
    */
   public function getAmount() {
     return $this->amount;
+  }
+
+  /**
+   * Gets the adjustment percentage.
+   *
+   * @return float|null
+   *   The adjustment percentage or NULL if not available.
+   */
+  public function getPercentage() {
+    return $this->percentage;
   }
 
   /**

--- a/modules/order/tests/src/Kernel/AdjustmentTest.php
+++ b/modules/order/tests/src/Kernel/AdjustmentTest.php
@@ -110,6 +110,7 @@ class AdjustmentTest extends CommerceKernelTestBase {
     $this->assertEquals('10% off', $adjustment->getLabel());
     $this->assertEquals('-1.00', $adjustment->getAmount()->getNumber());
     $this->assertEquals('USD', $adjustment->getAmount()->getCurrencyCode());
+    $this->assertEquals(NULL, $adjustment->getPercentage());
     $this->assertFalse($adjustment->isPositive());
     $this->assertTrue($adjustment->isNegative());
     $this->assertTrue($adjustment->isIncluded());

--- a/modules/promotion/src/Plugin/Commerce/PromotionOffer/OrderItemPercentageOff.php
+++ b/modules/promotion/src/Plugin/Commerce/PromotionOffer/OrderItemPercentageOff.php
@@ -32,7 +32,7 @@ class OrderItemPercentageOff extends PercentageOffBase {
       // @todo Change to label from UI when added in #2770731.
       'label' => t('Discount'),
       'amount' => $adjustment_amount->multiply('-1'),
-      'percentage' => $this->getAmount() * 100,
+      'percentage' => $this->getAmount(),
       'source_id' => $promotion->id(),
     ]));
   }

--- a/modules/promotion/src/Plugin/Commerce/PromotionOffer/OrderItemPercentageOff.php
+++ b/modules/promotion/src/Plugin/Commerce/PromotionOffer/OrderItemPercentageOff.php
@@ -32,6 +32,7 @@ class OrderItemPercentageOff extends PercentageOffBase {
       // @todo Change to label from UI when added in #2770731.
       'label' => t('Discount'),
       'amount' => $adjustment_amount->multiply('-1'),
+      'percentage' => $this->getAmount() * 100,
       'source_id' => $promotion->id(),
     ]));
   }

--- a/modules/promotion/src/Plugin/Commerce/PromotionOffer/OrderPercentageOff.php
+++ b/modules/promotion/src/Plugin/Commerce/PromotionOffer/OrderPercentageOff.php
@@ -32,7 +32,7 @@ class OrderPercentageOff extends PercentageOffBase {
       // @todo Change to label from UI when added in #2770731.
       'label' => t('Discount'),
       'amount' => $adjustment_amount->multiply('-1'),
-      'percentage' => $this->getAmount() * 100,
+      'percentage' => $this->getAmount(),
       'source_id' => $promotion->id(),
     ]));
   }

--- a/modules/promotion/src/Plugin/Commerce/PromotionOffer/OrderPercentageOff.php
+++ b/modules/promotion/src/Plugin/Commerce/PromotionOffer/OrderPercentageOff.php
@@ -32,6 +32,7 @@ class OrderPercentageOff extends PercentageOffBase {
       // @todo Change to label from UI when added in #2770731.
       'label' => t('Discount'),
       'amount' => $adjustment_amount->multiply('-1'),
+      'percentage' => $this->getAmount() * 100,
       'source_id' => $promotion->id(),
     ]));
   }

--- a/modules/promotion/tests/src/Kernel/PromotionOfferTest.php
+++ b/modules/promotion/tests/src/Kernel/PromotionOfferTest.php
@@ -238,7 +238,7 @@ class PromotionOfferTest extends CommerceKernelTestBase {
     $adjustment = reset($adjustments);
     // Adjustment for 50% of the order item total.
     $this->assertEquals(new Price('-5.00', 'USD'), $adjustment->getAmount());
-    $this->assertEquals('50', $adjustment->getPercentage());
+    $this->assertEquals('0.50', $adjustment->getPercentage());
     // Adjustments don't affect total order item price, but the order's total.
     $this->assertEquals(new Price('20.00', 'USD'), $order_item->getTotalPrice());
 

--- a/modules/promotion/tests/src/Kernel/PromotionOfferTest.php
+++ b/modules/promotion/tests/src/Kernel/PromotionOfferTest.php
@@ -238,6 +238,7 @@ class PromotionOfferTest extends CommerceKernelTestBase {
     $adjustment = reset($adjustments);
     // Adjustment for 50% of the order item total.
     $this->assertEquals(new Price('-5.00', 'USD'), $adjustment->getAmount());
+    $this->assertEquals('50', $adjustment->getPercentage());
     // Adjustments don't affect total order item price, but the order's total.
     $this->assertEquals(new Price('20.00', 'USD'), $order_item->getTotalPrice());
 

--- a/modules/tax/src/Plugin/Commerce/TaxType/LocalTaxTypeBase.php
+++ b/modules/tax/src/Plugin/Commerce/TaxType/LocalTaxTypeBase.php
@@ -168,7 +168,7 @@ abstract class LocalTaxTypeBase extends TaxTypeBase implements LocalTaxTypeInter
           'type' => 'tax',
           'label' => $zone->getDisplayLabel(),
           'amount' => $negate ? $tax_amount->multiply('-1') : $tax_amount,
-          'percentage' => $rate_amount * 100,
+          'percentage' => $rate_amount,
           'source_id' => $this->entityId . '|' . $zone->getId() . '|' . $rate->getId(),
           'included' => !$negate && $this->isDisplayInclusive(),
         ]));

--- a/modules/tax/src/Plugin/Commerce/TaxType/LocalTaxTypeBase.php
+++ b/modules/tax/src/Plugin/Commerce/TaxType/LocalTaxTypeBase.php
@@ -168,6 +168,7 @@ abstract class LocalTaxTypeBase extends TaxTypeBase implements LocalTaxTypeInter
           'type' => 'tax',
           'label' => $zone->getDisplayLabel(),
           'amount' => $negate ? $tax_amount->multiply('-1') : $tax_amount,
+          'percentage' => $rate_amount * 100,
           'source_id' => $this->entityId . '|' . $zone->getId() . '|' . $rate->getId(),
           'included' => !$negate && $this->isDisplayInclusive(),
         ]));


### PR DESCRIPTION
Kept $percentage as float (not integer) as percentage may not always be integer.