### PR TITLE
2906360: Split Offsite interface onNotify method to a new interface

### DIFF
--- a/modules/payment/src/Controller/OffsitePaymentController.php
+++ b/modules/payment/src/Controller/OffsitePaymentController.php
@@ -7,6 +7,7 @@ use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_payment\Entity\PaymentGatewayInterface;
 use Drupal\commerce_payment\Exception\PaymentGatewayException;
 use Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\OffsitePaymentGatewayInterface;
+use Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\OffsitePaymentNotificationInterface;
 use Drupal\Core\Access\AccessException;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -120,7 +121,7 @@ class OffsitePaymentController implements ContainerInjectionInterface {
    */
   public function notifyPage(PaymentGatewayInterface $commerce_payment_gateway, Request $request) {
     $payment_gateway_plugin = $commerce_payment_gateway->getPlugin();
-    if (!$payment_gateway_plugin instanceof OffsitePaymentGatewayInterface) {
+    if (!$payment_gateway_plugin instanceof OffsitePaymentNotificationInterface) {
       throw new AccessException('Invalid payment gateway provided.');
     }
 

--- a/modules/payment/src/Controller/OffsitePaymentController.php
+++ b/modules/payment/src/Controller/OffsitePaymentController.php
@@ -7,7 +7,7 @@ use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_payment\Entity\PaymentGatewayInterface;
 use Drupal\commerce_payment\Exception\PaymentGatewayException;
 use Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\OffsitePaymentGatewayInterface;
-use Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\OffsitePaymentNotificationInterface;
+use Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\SupportsNotificationsInterface;
 use Drupal\Core\Access\AccessException;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -121,7 +121,7 @@ class OffsitePaymentController implements ContainerInjectionInterface {
    */
   public function notifyPage(PaymentGatewayInterface $commerce_payment_gateway, Request $request) {
     $payment_gateway_plugin = $commerce_payment_gateway->getPlugin();
-    if (!$payment_gateway_plugin instanceof OffsitePaymentNotificationInterface) {
+    if (!$payment_gateway_plugin instanceof SupportsNotificationsInterface) {
       throw new AccessException('Invalid payment gateway provided.');
     }
 

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/OffsitePaymentGatewayInterface.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/OffsitePaymentGatewayInterface.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
  * the payment at the payment provider, they will be redirected back to the
  * cancel url.
  */
-interface OffsitePaymentGatewayInterface extends PaymentGatewayInterface {
+interface OffsitePaymentGatewayInterface extends PaymentGatewayInterface, OffsitePaymentNotificationInterface {
 
   /**
    * Gets the URL to the "notify" page.
@@ -62,22 +62,5 @@ interface OffsitePaymentGatewayInterface extends PaymentGatewayInterface {
    *   The request.
    */
   public function onCancel(OrderInterface $order, Request $request);
-
-  /**
-   * Processes the "notify" request.
-   *
-   * Note:
-   * This method can't throw exceptions on failure because some payment
-   * providers expect an error response to be returned in that case.
-   * Therefore, the method can log the error itself and then choose which
-   * response to return.
-   *
-   * @param \Symfony\Component\HttpFoundation\Request $request
-   *   The request.
-   *
-   * @return \Symfony\Component\HttpFoundation\Response|null
-   *   The response, or NULL to return an empty HTTP 200 response.
-   */
-  public function onNotify(Request $request);
 
 }

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/OffsitePaymentGatewayInterface.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/OffsitePaymentGatewayInterface.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
  * the payment at the payment provider, they will be redirected back to the
  * cancel url.
  */
-interface OffsitePaymentGatewayInterface extends PaymentGatewayInterface, OffsitePaymentNotificationInterface {
+interface OffsitePaymentGatewayInterface extends PaymentGatewayInterface, SupportsNotificationsInterface {
 
   /**
    * Gets the URL to the "notify" page.

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/OffsitePaymentNotificationInterface.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/OffsitePaymentNotificationInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\Commerce\PaymentGateway;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Defines the interface for gateways which receive payment notifications.
+ */
+interface OffsitePaymentNotificationInterface {
+
+  /**
+   * Processes the "notify" request.
+   *
+   * Note:
+   * This method can't throw exceptions on failure because some payment
+   * providers expect an error response to be returned in that case.
+   * Therefore, the method can log the error itself and then choose which
+   * response to return.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response|null
+   *   The response, or NULL to return an empty HTTP 200 response.
+   */
+  public function onNotify(Request $request);
+
+}

--- a/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsNotificationsInterface.php
+++ b/modules/payment/src/Plugin/Commerce/PaymentGateway/SupportsNotificationsInterface.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Defines the interface for gateways which receive payment notifications.
  */
-interface OffsitePaymentNotificationInterface {
+interface SupportsNotificationsInterface {
 
   /**
    * Processes the "notify" request.


### PR DESCRIPTION
This is from https://www.drupal.org/node/2906360

We are developing a payment gateway in Bolivia that uses cash payments in stores (https://www.drupal.org/project/commerce_pagos_net). The plugin is implementing both the OnsitePaymentInterface (because during checkout we call a web service to send the code that the user will have to present at the physical store to pay) and also implements the OffistePaymentInterface, because the payments provider sends a JSON back to our site once the user pays in any store. It works right now because in the PaymentProcess class, the `if` checks before if we are implementing the OnsitePaymentInterface, but if the if order changed then it would no longer work. I think it would be better to separate the onNotify method of the OffsitePaymentInterface to another interface so that any payment gateway can implement the onNotify method and use the OffsitePaymentController.