### PR TITLE
In the OrderStore condition plugin, use the correct storage for stores

### DIFF
--- a/modules/order/src/Plugin/Commerce/Condition/OrderStore.php
+++ b/modules/order/src/Plugin/Commerce/Condition/OrderStore.php
@@ -45,7 +45,7 @@ class OrderStore extends ConditionBase implements ContainerFactoryPluginInterfac
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
-    $this->storeStorage = $entity_type_manager->getStorage('commerce_product');
+    $this->storeStorage = $entity_type_manager->getStorage('commerce_store');
   }
 
   /**


### PR DESCRIPTION
When creating a condition based on stores, the wrong UUIDs are saved. They are those of the product rather than the store.