### PR TITLE
New test AjaxLoadedCartFormText.php.

### DIFF
--- a/modules/cart/tests/modules/commerce_cart_test/config/install/views.view.test_ajax_cart_forms.yml
+++ b/modules/cart/tests/modules/commerce_cart_test/config/install/views.view.test_ajax_cart_forms.yml
@@ -1,0 +1,217 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+id: test_ajax_paged_cart_forms
+label: 'Test Ajax Paged Cart Forms (Rendered products)'
+module: views
+description: ''
+tag: ''
+base_table: commerce_product_field_data
+base_field: product_id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 1
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+      row:
+        type: 'entity:commerce_product'
+      fields:
+        title:
+          table: commerce_product_field_data
+          field: title
+          id: title
+          entity_type: null
+          entity_field: title
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          id: status
+          table: commerce_product_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: commerce_product
+          entity_field: status
+          plugin_id: boolean
+      sorts:
+        title:
+          id: title
+          table: commerce_product_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: commerce_product
+          entity_field: title
+          plugin_id: standard
+      title: 'Test Ajax Cart Forms'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      use_ajax: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: test-ajax-paged-cart-forms
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+      tags: {  }

--- a/modules/cart/tests/src/FunctionalJavascript/AjaxLoadedCartFormTest.php
+++ b/modules/cart/tests/src/FunctionalJavascript/AjaxLoadedCartFormTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\Tests\commerce_cart\FunctionalJavascript;
+
+use Drupal\commerce_order\Entity\Order;
+use Drupal\commerce_product\Entity\ProductVariationType;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Tests\commerce\FunctionalJavascript\JavascriptTestTrait;
+use Drupal\Tests\commerce_cart\Functional\CartBrowserTestBase;
+
+/**
+ * Test add to cart forms on views with ajax pagers.
+ *
+ * @group commerce
+ */
+class AjaxLoadedCartFormTest extends CartBrowserTestBase {
+
+  use JavascriptTestTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'commerce_cart_test',
+    'commerce_cart_big_pipe',
+  ];
+
+  /**
+   * @var \Drupal\commerce_product\Entity\ProductAttributeValueInterface[]
+   */
+  protected $colorAttributes = [];
+
+  /**
+   * @var \Drupal\commerce_product\Entity\ProductAttributeValueInterface[]
+   */
+  protected $sizeAttributes = [];
+
+  /**
+   * @var \Drupal\commerce_product\Entity\ProductInterface[]
+   */
+  protected $products = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->maximumMetaRefreshCount = 0;
+
+    // Delete parent test product.
+    $this->variation->getProduct()->setUnpublished();
+    $this->variation->getProduct()->save();
+
+    /** @var \Drupal\Core\Entity\Entity\EntityFormDisplay $order_item_form_display */
+    $order_item_form_display = EntityFormDisplay::load('commerce_order_item.default.add_to_cart');
+    $order_item_form_display->setComponent('quantity', [
+      'type' => 'number',
+    ]);
+    $order_item_form_display->save();
+
+    $variation_type = ProductVariationType::load('default');
+    $color_attributes = $this->createAttributeSet($variation_type, 'color', [
+      'red' => 'Red',
+      'blue' => 'Blue',
+    ]);
+    $this->colorAttributes = $color_attributes;
+    $size_attributes = $this->createAttributeSet($variation_type, 'size', [
+      'small' => 'Small',
+      'medium' => 'Medium',
+      'large' => 'Large',
+    ]);
+    $this->sizeAttributes = $size_attributes;
+
+    $attribute_values_matrix = [
+      ['red', 'small', '10.00'],
+      ['red', 'medium', '10.33'],
+      ['red', 'large', '10.66'],
+      ['blue', 'small', '20.00'],
+      ['blue', 'medium', '20.33'],
+      ['blue', 'large', '20.66'],
+    ];
+
+    for ($i = 1; $i < 5; $i++) {
+      // Create a product variation.
+      $variations = [];
+      // Generate variations off of the attributes values matrix.
+      foreach ($attribute_values_matrix as $key => $value) {
+        $variation = $this->createEntity('commerce_product_variation', [
+          'type' => 'default',
+          'sku' => $this->randomMachineName(),
+          'price' => [
+            'number' => $value[2],
+            'currency_code' => 'USD',
+          ],
+          'attribute_color' => $color_attributes[$value[0]],
+          'attribute_size' => $size_attributes[$value[1]],
+        ]);
+        $variations[] = $variation;
+      }
+
+      $this->products[] = $this->createEntity('commerce_product', [
+        'type' => 'default',
+        'title' => $this->randomMachineName(),
+        'stores' => [$this->store],
+        'variations' => $variations,
+      ]);
+    }
+  }
+
+  /**
+   * Test add to cart forms views with ajax pagers.
+   *
+   * @group debug
+   */
+  public function testAjaxRenderedProducts() {
+    // View of rendered products, each containing an add to cart form.
+    $this->drupalGet('/test-ajax-paged-cart-forms');
+
+    // Paginate View.
+    $pager = $this->getSession()->getPage()->findAll('css', '.view-test-ajax-paged-cart-forms .pager__item--next');
+    $pager[0]->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
+    $initial_price = $this->getSession()->getPage()->findAll('css', '.field--type-commerce-price .field__item');
+    $initial_price = $initial_price[0]->getText();
+
+    // Changing the product attributes should not cause /views/ajax to 404.
+    $forms = $this->getSession()->getPage()->findAll('css', '.commerce-order-item-add-to-cart-form');
+    $current_form = $forms[0];
+    $current_form->selectFieldOption('Color', 'Blue');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $forms[1]->selectFieldOption('Size', 'Large');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
+    // Check that price changed with new attribute selection.
+    $updated_price = $this->getSession()->getPage()->findAll('css', '.field--type-commerce-price .field__item');
+    $updated_price = $updated_price[0]->getText();
+    $this->assertNotEqual($initial_price, $updated_price);
+  }
+
+}


### PR DESCRIPTION
Products loaded via views ajax-enabled pagination currently have broken Add to Cart forms. 

Attempting to modify the ajax-loaded products attributes will cause /views/ajax to throw a 404. 

Attempting to add the ajax-loaded product to ones cart (even without modifying the attributes) redirects to /views/ajax, which renders the 404 page.

This is only the failing test case. I tried to keep it as minimal as possible.