### PR TITLE
Feature/usage limit multiple

### DIFF
--- a/modules/promotion/commerce_promotion.install
+++ b/modules/promotion/commerce_promotion.install
@@ -115,3 +115,21 @@ function commerce_promotion_update_8203() {
     ]);
   $entity_definition_update->installFieldStorageDefinition('usage_limit', 'commerce_promotion_coupon', 'commerce_promotion', $storage_definition);
 }
+
+/**
+ * Add the usage_limit_per_client field to promotions.
+ */
+function commerce_promotion_update_8204() {
+  $entity_definition_update = \Drupal::entityDefinitionUpdateManager();
+
+  $storage_definition = BaseFieldDefinition::create('integer')
+    ->setLabel(t('Number of uses per client'))
+    ->setDescription(t('The maximum number of times the promotion can be used per client. 0 for unlimited.'))
+    ->setDefaultValue(0)
+    ->setSetting('parent', 'usage_limit')
+    ->setDisplayOptions('form', [
+      'type' => 'commerce_usage_limit_per_client',
+      'weight' => 4,
+    ]);
+  $entity_definition_update->installFieldStorageDefinition('usage_limit_per_client', 'commerce_promotion', 'commerce_promotion', $storage_definition);
+}

--- a/modules/promotion/src/Entity/PromotionInterface.php
+++ b/modules/promotion/src/Entity/PromotionInterface.php
@@ -229,6 +229,27 @@ interface PromotionInterface extends ContentEntityInterface, EntityStoresInterfa
   public function setUsageLimit($usage_limit);
 
   /**
+   * Gets the promotion usage limit per client.
+   *
+   * Represents maximum number of times the promotion can be used per client.
+   * 0 for unlimited.
+   *
+   * @return int
+   *   The promotion usage limit per client.
+   */
+  public function getUsageLimitPerClient();
+
+  /**
+   * Sets the promotion usage limit per client.
+   *
+   * @param int $usage_limit_per_client
+   *   The promotion usage limit per client.
+   *
+   * @return $this
+   */
+  public function setUsageLimitPerClient($usage_limit_per_client);
+
+  /**
    * Gets the promotion start date.
    *
    * @return \Drupal\Core\Datetime\DrupalDateTime

--- a/modules/promotion/src/Form/PromotionForm.php
+++ b/modules/promotion/src/Form/PromotionForm.php
@@ -79,6 +79,7 @@ class PromotionForm extends ContentEntityForm {
       'start_date' => 'date_details',
       'end_date' => 'date_details',
       'usage_limit' => 'usage_details',
+      'usage_limit_per_client' => 'usage_details',
       'compatibility' => 'compatibility_details',
     ];
 

--- a/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
+++ b/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\commerce_promotion\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of 'commerce_usage_limit_per_client'.
+ *
+ * @FieldWidget(
+ *   id = "commerce_usage_limit_per_client",
+ *   label = @Translation("Usage limit per client"),
+ *   field_types = {
+ *     "integer"
+ *   }
+ * )
+ */
+class UsageLimitPerClientWidget extends WidgetBase {
+
+  /**
+   * The name of the parent field using this widget.
+   *
+   * @var string
+   */
+  protected $parent;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $value = isset($items[$delta]->value) ? $items[$delta]->value : NULL;
+    // We need to know the name of the field using this widget,
+    // in order to then adapt his behavior.
+    if (!empty($this->fieldDefinition->getItemDefinition()->getSetting('parent'))) {
+      $this->parent = $this->fieldDefinition->getItemDefinition()->getSetting('parent');
+    }
+    else {
+      $this->parent = $this->fieldDefinition->getName();
+    }
+
+    // A radio button of the parent element informs about the active state,
+    // or not of the usage limitation. The visible status here depends on it.
+    $radio_parents = array_merge($form['#parents'], [$this->parent, 0, 'limit']);
+    $radio_path = array_shift($radio_parents);
+    $radio_path .= '[' . implode('][', $radio_parents) . ']';
+
+    $element['usage_limit_per_client'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Number of uses per client'),
+      '#default_value' => $value ?: 10,
+      '#description' => $this->t('Limit the number of uses per client. Keep empty to no limitations.'),
+      '#states' => [
+        'invisible' => [
+          ':input[name="' . $radio_path . '"]' => ['value' => 0],
+        ],
+      ],
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    $new_values = [];
+    foreach ($values as $key => $value) {
+      if (!empty($form_state->getValue($this->parent)[$key]['limit'])) {
+        $new_values[$key] = $value['usage_limit_per_client'];
+      }
+    }
+    return $new_values;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function isApplicable(FieldDefinitionInterface $field_definition) {
+    $entity_type = $field_definition->getTargetEntityTypeId();
+    $field_name = $field_definition->getName();
+    return in_array($entity_type, ['commerce_promotion', 'commerce_promotion_coupon']) && $field_name == 'usage_limit_per_client';
+  }
+}

--- a/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
+++ b/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
@@ -83,4 +83,5 @@ class UsageLimitPerClientWidget extends WidgetBase {
     $field_name = $field_definition->getName();
     return in_array($entity_type, ['commerce_promotion', 'commerce_promotion_coupon']) && $field_name == 'usage_limit_per_client';
   }
+
 }

--- a/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
+++ b/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
@@ -50,7 +50,7 @@ class UsageLimitPerClientWidget extends WidgetBase {
     $element['usage_limit_per_client'] = [
       '#type' => 'number',
       '#title' => $this->t('Number of uses per client'),
-      '#default_value' => $value,
+      '#default_value' => $value?: NULL,
       '#description' => $this->t('Limit the number of uses per client.'),
       '#states' => [
         'invisible' => [

--- a/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
+++ b/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
@@ -68,7 +68,7 @@ class UsageLimitPerClientWidget extends WidgetBase {
   public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
     $new_values = [];
     foreach ($values as $key => $value) {
-      if (!empty($form_state->getValue($this->parent)[$key]['limit'])) {
+      if (!empty($form_state->getValue('usage_limit')[$key]['limit'])) {
         $new_values[$key] = $value['usage_limit_per_client'];
       }
     }

--- a/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
+++ b/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitPerClientWidget.php
@@ -50,8 +50,8 @@ class UsageLimitPerClientWidget extends WidgetBase {
     $element['usage_limit_per_client'] = [
       '#type' => 'number',
       '#title' => $this->t('Number of uses per client'),
-      '#default_value' => $value ?: 10,
-      '#description' => $this->t('Limit the number of uses per client. Keep empty to no limitations.'),
+      '#default_value' => $value,
+      '#description' => $this->t('Limit the number of uses per client.'),
       '#states' => [
         'invisible' => [
           ':input[name="' . $radio_path . '"]' => ['value' => 0],

--- a/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitWidget.php
+++ b/modules/promotion/src/Plugin/Field/FieldWidget/UsageLimitWidget.php
@@ -101,7 +101,6 @@ class UsageLimitWidget extends WidgetBase implements ContainerFactoryPluginInter
     $element['usage_limit'] = [
       '#type' => 'number',
       '#title' => $this->t('Number of uses'),
-      '#title_display' => 'invisible',
       '#default_value' => $value ?: 10,
       '#description' => $this->t('Current usage: @usage.', ['@usage' => $formatted_usage]),
       '#states' => [

--- a/modules/promotion/src/PromotionStorage.php
+++ b/modules/promotion/src/PromotionStorage.php
@@ -108,7 +108,7 @@ class PromotionStorage extends CommerceContentEntityStorage implements Promotion
     $usages_per_client = $this->usage->loadMultiple($promotions_with_usage_limits, $order->getEmail());
     foreach ($promotions_with_usage_limits as $promotion_id => $promotion) {
       /** @var \Drupal\commerce_promotion\Entity\PromotionInterface $promotion */
-      if (($promotion->getUsageLimit() <= $usages[$promotion_id]) || $promotion->getUsageLimitPerClient() <= $usages_per_client[$promotion_id]) {
+      if (($promotion->getUsageLimit() && $promotion->getUsageLimit() <= $usages[$promotion_id]) || ($promotion->getUsageLimitPerClient() && $promotion->getUsageLimitPerClient() <= $usages_per_client[$promotion_id])) {
         unset($promotions[$promotion_id]);
       }
     }

--- a/modules/promotion/src/PromotionStorage.php
+++ b/modules/promotion/src/PromotionStorage.php
@@ -108,7 +108,7 @@ class PromotionStorage extends CommerceContentEntityStorage implements Promotion
     $usages_per_client = $this->usage->loadMultiple($promotions_with_usage_limits, $order->getEmail());
     foreach ($promotions_with_usage_limits as $promotion_id => $promotion) {
       /** @var \Drupal\commerce_promotion\Entity\PromotionInterface $promotion */
-      if (($promotion->getUsageLimit() <= $usages[$promotion_id]) || $promotion->getUsageLimitPerClient() <= $usages_per_client[$promotion_id])  {
+      if (($promotion->getUsageLimit() <= $usages[$promotion_id]) || $promotion->getUsageLimitPerClient() <= $usages_per_client[$promotion_id]) {
         unset($promotions[$promotion_id]);
       }
     }

--- a/modules/promotion/src/PromotionStorage.php
+++ b/modules/promotion/src/PromotionStorage.php
@@ -105,9 +105,10 @@ class PromotionStorage extends CommerceContentEntityStorage implements Promotion
       return !empty($promotion->getUsageLimit());
     });
     $usages = $this->usage->loadMultiple($promotions_with_usage_limits);
+    $usages_per_client = $this->usage->loadMultiple($promotions_with_usage_limits, $order->getEmail());
     foreach ($promotions_with_usage_limits as $promotion_id => $promotion) {
       /** @var \Drupal\commerce_promotion\Entity\PromotionInterface $promotion */
-      if ($promotion->getUsageLimit() <= $usages[$promotion_id]) {
+      if (($promotion->getUsageLimit() <= $usages[$promotion_id]) || $promotion->getUsageLimitPerClient() <= $usages_per_client[$promotion_id])  {
         unset($promotions[$promotion_id]);
       }
     }

--- a/modules/promotion/tests/src/Kernel/Entity/PromotionTest.php
+++ b/modules/promotion/tests/src/Kernel/Entity/PromotionTest.php
@@ -84,6 +84,8 @@ class PromotionTest extends CommerceKernelTestBase {
    * @covers ::hasCoupon
    * @covers ::getUsageLimit
    * @covers ::setUsageLimit
+   * @covers ::getUsageLimitPerClient
+   * @covers ::setUsageLimitPerClient
    * @covers ::getStartDate
    * @covers ::setStartDate
    * @covers ::getEndDate
@@ -154,6 +156,9 @@ class PromotionTest extends CommerceKernelTestBase {
 
     $promotion->setUsageLimit(10);
     $this->assertEquals(10, $promotion->getUsageLimit());
+
+    $promotion->setUsageLimitPerClient(5);
+    $this->assertEquals(5, $promotion->getUsageLimitPerClient());
 
     $promotion->setStartDate(new DrupalDateTime('2017-01-01'));
     $this->assertEquals('2017-01-01', $promotion->getStartDate()->format('Y-m-d'));

--- a/modules/promotion/tests/src/Kernel/PromotionAvailabilityTest.php
+++ b/modules/promotion/tests/src/Kernel/PromotionAvailabilityTest.php
@@ -207,4 +207,5 @@ class PromotionAvailabilityTest extends CommerceKernelTestBase {
     \Drupal::service('commerce_promotion.usage')->register($this->order, $promotion);
     $this->assertFalse($promotion->available($this->order));
   }
+
 }

--- a/modules/promotion/tests/src/Kernel/PromotionAvailabilityTest.php
+++ b/modules/promotion/tests/src/Kernel/PromotionAvailabilityTest.php
@@ -91,6 +91,7 @@ class PromotionAvailabilityTest extends CommerceKernelTestBase {
       'order_types' => ['default'],
       'stores' => [$this->store->id()],
       'usage_limit' => 2,
+      'usage_limit_per_client' => 1,
       'status' => TRUE,
     ]);
     $promotion->save();
@@ -118,6 +119,7 @@ class PromotionAvailabilityTest extends CommerceKernelTestBase {
       'order_types' => ['default'],
       'stores' => [$this->store->id()],
       'usage_limit' => 1,
+      'usage_limit_per_client' => 1,
       'status' => TRUE,
     ]);
     $promotion->save();
@@ -150,6 +152,7 @@ class PromotionAvailabilityTest extends CommerceKernelTestBase {
       'order_types' => ['default'],
       'stores' => [$this->store->id()],
       'usage_limit' => 1,
+      'usage_limit_per_client' => 1,
       'status' => TRUE,
     ]);
     $promotion->save();
@@ -175,6 +178,7 @@ class PromotionAvailabilityTest extends CommerceKernelTestBase {
       'order_types' => ['default'],
       'stores' => [$this->store->id()],
       'usage_limit' => 2,
+      'usage_limit_per_client' => 2,
       'status' => TRUE,
     ]);
     $promotion->save();
@@ -186,4 +190,21 @@ class PromotionAvailabilityTest extends CommerceKernelTestBase {
     $this->assertFalse($promotion->available($this->order));
   }
 
+  /**
+   * Tests the usage count per client logic.
+   */
+  public function testUsagePerClientCount() {
+    $promotion = Promotion::create([
+      'order_types' => ['default'],
+      'stores' => [$this->store->id()],
+      'usage_limit' => 2,
+      'usage_limit_per_client' => 1,
+      'status' => TRUE,
+    ]);
+    $promotion->save();
+    $this->assertTrue($promotion->available($this->order));
+
+    \Drupal::service('commerce_promotion.usage')->register($this->order, $promotion);
+    $this->assertFalse($promotion->available($this->order));
+  }
 }


### PR DESCRIPTION
Hi, I work on feature asked by https://www.drupal.org/node/2902495.
PR add feature to Promotion usage limit. We can define global usage limit and usage limit per user.
On click on radio button to enable usage limit, usage limit per user field is displayed below the global usage limit field. Both usage limits are checked to limit the promotion use.