### PR TITLE
Issue #2917571: Set payment_gateway and payment_method fields optiona…

### DIFF
--- a/modules/payment/commerce_payment.install
+++ b/modules/payment/commerce_payment.install
@@ -63,4 +63,3 @@ function commerce_payment_update_8202() {
   $field_definition->setRequired(FALSE);
   $entity_definition_update->updateFieldStorageDefinition($field_definition);
 }
-

--- a/modules/payment/commerce_payment.install
+++ b/modules/payment/commerce_payment.install
@@ -47,3 +47,20 @@ function commerce_payment_update_8201() {
     ->setDisplayConfigurable('view', TRUE);
   $entity_definition_update->installFieldStorageDefinition('completed', 'commerce_payment', 'commerce_payment', $storage_definition);
 }
+
+/**
+ * Set payment_gateway and payment_method entity reference fields of order
+ * optional.
+ */
+function commerce_payment_update_8202() {
+  $entity_definition_update = \Drupal::entityDefinitionUpdateManager();
+
+  $field_definition = $entity_definition_update->getFieldStorageDefinition('payment_gateway', 'commerce_order');
+  $field_definition->setRequired(FALSE);
+  $entity_definition_update->updateFieldStorageDefinition($field_definition);
+
+  $field_definition = $entity_definition_update->getFieldStorageDefinition('payment_method', 'commerce_order');
+  $field_definition->setRequired(FALSE);
+  $entity_definition_update->updateFieldStorageDefinition($field_definition);
+}
+

--- a/modules/payment/commerce_payment.install
+++ b/modules/payment/commerce_payment.install
@@ -49,8 +49,7 @@ function commerce_payment_update_8201() {
 }
 
 /**
- * Set payment_gateway and payment_method entity reference fields of order
- * optional.
+ * Make payment_gateway and payment_method order fields optional.
  */
 function commerce_payment_update_8202() {
   $entity_definition_update = \Drupal::entityDefinitionUpdateManager();

--- a/modules/payment/commerce_payment.module
+++ b/modules/payment/commerce_payment.module
@@ -29,13 +29,11 @@ function commerce_payment_entity_base_field_info(EntityTypeInterface $entity_typ
     $fields['payment_gateway'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Payment gateway'))
       ->setDescription(t('The payment gateway.'))
-      ->setRequired(TRUE)
       ->setSetting('target_type', 'commerce_payment_gateway');
 
     $fields['payment_method'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Payment method'))
       ->setDescription(t('The payment method.'))
-      ->setRequired(TRUE)
       ->setSetting('target_type', 'commerce_payment_method');
 
     return $fields;


### PR DESCRIPTION
**Problem/Motivation**

Entity reference fields payment_gateway and payment_method are required in commerce_order.
Those fields are never required in UI (and making order from BO or FO).

In another hand, this required fields make rest resource creation fail because they are required and there is no way to bypass this.

I don't see reasons to make them required since order is created at first as cart wihtout data in those fields, and add them later (if needed, but not necessary).

**Proposed resolution**

Make payment_gateway and payment_method entity reference fields of commerce_order optional.

See https://www.drupal.org/node/2917571
