### PR TITLE
Issue #2898217 by tilenav: Delete payment methods when their payment gateway is deleted

### DIFF
--- a/modules/payment/src/Entity/PaymentGateway.php
+++ b/modules/payment/src/Entity/PaymentGateway.php
@@ -282,7 +282,8 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
       if (count($payment_methods) < 50) {
         // If there is less than 50 payment methods, we delete them straight away.
         $payment_method_storage->delete($payment_methods);
-      } else {
+      }
+      else {
         // Else we queue them for deletion.
         $queue = \Drupal::queue('payment_methods_delete_queue');
         foreach (array_chunk($payment_methods, 50) as $payment_methods_chunk) {

--- a/modules/payment/src/Entity/PaymentGateway.php
+++ b/modules/payment/src/Entity/PaymentGateway.php
@@ -6,6 +6,7 @@ use Drupal\commerce\CommerceSinglePluginCollection;
 use Drupal\commerce\ConditionGroup;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\Core\Entity\EntityStorageInterface;
 
 /**
  * Defines the payment gateway entity class.
@@ -253,7 +254,12 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
   protected function getPluginCollection() {
     if (!$this->pluginCollection) {
       $plugin_manager = \Drupal::service('plugin.manager.commerce_payment_gateway');
-      $this->pluginCollection = new CommerceSinglePluginCollection($plugin_manager, $this->plugin, $this->configuration, $this->id);
+      $this->pluginCollection = new CommerceSinglePluginCollection(
+        $plugin_manager,
+        $this->plugin,
+        $this->configuration,
+        $this->id
+      );
     }
     return $this->pluginCollection;
   }

--- a/modules/payment/src/Entity/PaymentGateway.php
+++ b/modules/payment/src/Entity/PaymentGateway.php
@@ -267,7 +267,7 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
     /** @var \Drupal\commerce_payment\PaymentMethodStorageInterface $payment_method_storage */
     $payment_method_storage = \Drupal::service('entity_type.manager')
       ->getStorage('commerce_payment_method');
-    
+
     foreach ($entities as $payment_gateway) {
       $payment_methods = $payment_method_storage->loadByPaymentGateway($payment_gateway);
       if (empty($payment_methods)) {
@@ -279,7 +279,6 @@ class PaymentGateway extends ConfigEntityBase implements PaymentGatewayInterface
       } else {
         // Else we queue them for deletion.
         $queue = \Drupal::queue('payment_methods_delete_queue');
-        //$queue->createQueue();
         foreach (array_chunk($payment_methods, 50) as $payment_methods_chunk) {
           $queue->createItem($payment_methods_chunk);
         }

--- a/modules/payment/src/PaymentMethodStorage.php
+++ b/modules/payment/src/PaymentMethodStorage.php
@@ -125,4 +125,20 @@ class PaymentMethodStorage extends CommerceContentEntityStorage implements Payme
     return parent::doCreate($values);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function loadByPaymentGateway(PaymentGatewayInterface $payment_gateway) {
+    if (!($payment_gateway->getPlugin() instanceof SupportsStoredPaymentMethodsInterface)) {
+      return [];
+    }
+    $query = $this->getQuery()
+      ->condition('payment_gateway', $payment_gateway->id());
+    $result = $query->execute();
+    if (empty($result)) {
+      return [];
+    }
+    return $this->loadMultiple($result);
+  }
+
 }

--- a/modules/payment/src/PaymentMethodStorageInterface.php
+++ b/modules/payment/src/PaymentMethodStorageInterface.php
@@ -28,4 +28,13 @@ interface PaymentMethodStorageInterface extends ContentEntityStorageInterface {
    */
   public function loadReusable(UserInterface $account, PaymentGatewayInterface $payment_gateway, array $billing_countries = []);
 
+  /**
+   * @param \Drupal\commerce_payment\Entity\PaymentGatewayInterface $paymentGateway
+   *   The payment gateway.
+   *
+   * @return \Drupal\commerce_payment\Entity\PaymentMethodInterface[]
+   *   The payment methods.
+   */
+  public function loadByPaymentGateway(PaymentGatewayInterface $payment_gateway);
+
 }

--- a/modules/payment/src/PaymentMethodStorageInterface.php
+++ b/modules/payment/src/PaymentMethodStorageInterface.php
@@ -30,8 +30,8 @@ interface PaymentMethodStorageInterface extends ContentEntityStorageInterface {
 
   /**
    * Loads the payment methods for the given payment gateway.
-   * 
-   * @param \Drupal\commerce_payment\Entity\PaymentGatewayInterface $paymentGateway
+   *
+   * @param \Drupal\commerce_payment\Entity\PaymentGatewayInterface $payment_gateway
    *   The payment gateway.
    *
    * @return \Drupal\commerce_payment\Entity\PaymentMethodInterface[]

--- a/modules/payment/src/PaymentMethodStorageInterface.php
+++ b/modules/payment/src/PaymentMethodStorageInterface.php
@@ -29,6 +29,8 @@ interface PaymentMethodStorageInterface extends ContentEntityStorageInterface {
   public function loadReusable(UserInterface $account, PaymentGatewayInterface $payment_gateway, array $billing_countries = []);
 
   /**
+   * Loads the payment methods for the given payment gateway.
+   * 
    * @param \Drupal\commerce_payment\Entity\PaymentGatewayInterface $paymentGateway
    *   The payment gateway.
    *

--- a/modules/payment/src/Plugin/QueueWorker/PaymentMethodDeleteQueue.php
+++ b/modules/payment/src/Plugin/QueueWorker/PaymentMethodDeleteQueue.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\commerce_payment\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\QueueWorkerBase;
+
+/**
+ * Deletes payment methods in groups of 50.
+ *
+ * @QueueWorker(
+ *   id = "payment_methods_delete_queue",
+ *   title = @Translation("Queue for deletion of payment methods"),
+ *   cron = {"time" = 60}
+ * )
+ */
+class PaymentMethodDeleteQueue extends QueueWorkerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    /** @var \Drupal\commerce_payment\PaymentMethodStorageInterface $payment_method_storage */
+    $payment_method_storage = \Drupal::service('entity_type.manager')
+      ->getStorage('commerce_payment_method');
+    $payment_method_storage->delete($data);
+  }
+
+}


### PR DESCRIPTION
I hope this is the kind of queue you were expecting. Keep in mind that until the payment methods are deleted (cron run), users will receive an error on /user/{user}/payment-methods.