### PR TITLE
Issue 2919078 by nikathone: Displaying wrong coupon usage number

### DIFF
--- a/modules/promotion/src/CouponListBuilder.php
+++ b/modules/promotion/src/CouponListBuilder.php
@@ -73,7 +73,7 @@ class CouponListBuilder extends EntityListBuilder {
     $promotion = $this->routeMatch->getParameter('commerce_promotion');
     $coupons = $this->storage->loadMultipleByPromotion($promotion);
     // Load the usage counts for each coupon.
-    $this->usageCounts = $this->usage->loadMultiple($coupons);
+    $this->usageCounts = $this->usage->loadMultipleByCoupon($coupons);
 
     return $coupons;
   }


### PR DESCRIPTION
Not sure if this is a bug with promotion but under `Drupal\commerce_promotion\CouponListBuilder::load()` line 76 we have `$this->usageCounts = $this->usage->loadMultiple($coupons);` shouldn't this be `$this->usageCounts = $this->usage->loadMultipleByCoupon($coupons);`