### PR TITLE
According to OrderInterface, $order should be returned

### DIFF
--- a/modules/order/src/OrderRefresh.php
+++ b/modules/order/src/OrderRefresh.php
@@ -164,6 +164,8 @@ class OrderRefresh implements OrderRefreshInterface {
         $order_item->save();
       }
     }
+    
+    return $order;
   }
 
 }


### PR DESCRIPTION
I first thought the annotation in OrderInterface was wrong since order is an object, but in my case, using order refresh service to refresh an order should also return the order to get the up to date order.