### PR TITLE
Return NULL if referenced entity is not found

### DIFF
--- a/modules/payment/tests/src/Kernel/PaymentMethodStorageTest.php
+++ b/modules/payment/tests/src/Kernel/PaymentMethodStorageTest.php
@@ -120,7 +120,9 @@ class PaymentMethodStorageTest extends CommerceKernelTestBase {
     $payment_method_unlimited->save();
     // Confirm that the expired payment method was not loaded.
     $reusable_payment_methods = $this->storage->loadReusable($this->user, $this->paymentGateway);
-    $this->assertEquals([$payment_method_active->id(), $payment_method_unlimited->id()], array_keys($reusable_payment_methods));
+    $reusable_payment_methods = array_keys($reusable_payment_methods);
+    sort($reusable_payment_methods);
+    $this->assertEquals([$payment_method_active->id(), $payment_method_unlimited->id()], $reusable_payment_methods);
 
     // Confirm that anonymous users cannot have reusable payment methods.
     $payment_method_active->setOwnerId(0);

--- a/src/Entity/CommerceContentEntityBase.php
+++ b/src/Entity/CommerceContentEntityBase.php
@@ -23,7 +23,7 @@ class CommerceContentEntityBase extends ContentEntityBase implements CommerceCon
    */
   public function getTranslatedReferencedEntity($field_name) {
     $referenced_entities = $this->getTranslatedReferencedEntities($field_name);
-    return reset($referenced_entities);
+    return reset($referenced_entities) ?: NULL;
   }
 
   /**

--- a/src/Entity/CommerceContentEntityInterface.php
+++ b/src/Entity/CommerceContentEntityInterface.php
@@ -27,7 +27,7 @@ interface CommerceContentEntityInterface extends ContentEntityInterface {
    *   The entity reference field name.
    *
    * @return \Drupal\Core\Entity\ContentEntityInterface
-   *   The entity.
+   *   The entity, or NULL if not found.
    */
   public function getTranslatedReferencedEntity($field_name);
 


### PR DESCRIPTION
Methods such as `ProductVariation::getProduct`, `OrderItem::getPurchasedEntity` expect a NULL value if the referenced entity is not found.