### PR TITLE
Add registration fields to stores for commerce tax zones.

### DIFF
--- a/modules/tax/commerce_tax.module
+++ b/modules/tax/commerce_tax.module
@@ -40,6 +40,11 @@ function commerce_tax_entity_base_field_info(EntityTypeInterface $entity_type) {
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
 
+    $tax_plugin_manager = \Drupal::service('plugin.manager.commerce_tax_type');
+    foreach($tax_plugin_manager->getDefinitions() as $definition) {
+      $plugin = $tax_plugin_manager->createInstance($definition['id']);
+      $fields += $plugin->storeFields();
+    }
     return $fields;
   }
 }
@@ -58,6 +63,25 @@ function commerce_tax_form_commerce_store_form_alter(&$form, FormStateInterface 
     ];
     $form['prices_include_tax']['#group'] = 'tax_settings';
     $form['tax_registrations']['#group'] = 'tax_settings';
+    $settings = [];
+    $settings['#group'] = 'tax_settings';
+
+    // @todo Fix when https://www.drupal.org/project/drupal/issues/1149078 has
+    // landed. Ideally these should only show up for stores that have selected
+    // CA in tax registrations. However, the States API is broken for select
+    // elements with #multiple => TRUE.
+    /*
+    $settings['#states'] = [
+      'visible' => [
+        ':input[name^="tax_registrations"]' => ['value' => 'CA'],
+      ]
+    ];
+    */
+
+    $form['tax_ca_gst_number'] += $settings;
+    $form['tax_ca_pst_bc_number'] += $settings;
+    $form['tax_ca_pst_mb_number'] += $settings;
+    $form['tax_ca_qst_number'] += $settings;
   }
 }
 

--- a/modules/tax/commerce_tax.module
+++ b/modules/tax/commerce_tax.module
@@ -41,7 +41,7 @@ function commerce_tax_entity_base_field_info(EntityTypeInterface $entity_type) {
       ->setDisplayConfigurable('form', TRUE);
 
     $tax_plugin_manager = \Drupal::service('plugin.manager.commerce_tax_type');
-    foreach($tax_plugin_manager->getDefinitions() as $definition) {
+    foreach ($tax_plugin_manager->getDefinitions() as $definition) {
       $plugin = $tax_plugin_manager->createInstance($definition['id']);
       $fields += $plugin->storeFields();
     }
@@ -70,13 +70,11 @@ function commerce_tax_form_commerce_store_form_alter(&$form, FormStateInterface 
     // landed. Ideally these should only show up for stores that have selected
     // CA in tax registrations. However, the States API is broken for select
     // elements with #multiple => TRUE.
-    /*
-    $settings['#states'] = [
-      'visible' => [
-        ':input[name^="tax_registrations"]' => ['value' => 'CA'],
-      ]
-    ];
-    */
+    // $settings['#states'] = [
+    //   'visible' => [
+    //     ':input[name^="tax_registrations"]' => ['value' => 'CA'],
+    //   ]
+    // ];
 
     $form['tax_ca_gst_number'] += $settings;
     $form['tax_ca_pst_bc_number'] += $settings;

--- a/modules/tax/src/Plugin/Commerce/TaxType/CanadianSalesTax.php
+++ b/modules/tax/src/Plugin/Commerce/TaxType/CanadianSalesTax.php
@@ -5,6 +5,7 @@ namespace Drupal\commerce_tax\Plugin\Commerce\TaxType;
 use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\commerce_tax\TaxZone;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\profile\Entity\ProfileInterface;
 
@@ -41,18 +42,24 @@ class CanadianSalesTax extends LocalTaxTypeBase {
   protected function matchesRegistrations(StoreInterface $store) {
     $store_registrations = $store->get('tax_registrations')->getValue();
     $store_registrations = array_column($store_registrations, 'value');
-    return in_array('CA', $store_registrations);
+    if (in_array('CA', $store_registrations)) {
+      foreach ($this->getZones() as $zone) {
+        if ($zone->isRegistered($store)) {
+          return TRUE;
+        }
+      }
+    }
   }
 
   /**
    * {@inheritdoc}
    */
-  protected function resolveZones(OrderItemInterface $order_item, ProfileInterface $customer_profile) {
+  protected function resolveZones(OrderItemInterface $order_item, ProfileInterface $customer_profile, StoreInterface $store) {
     $customer_address = $customer_profile->get('address')->first();
     if ($customer_address->getCountryCode() != 'CA') {
       return [];
     }
-    return parent::resolveZones($order_item, $customer_profile);
+    return parent::resolveZones($order_item, $customer_profile, $store);
   }
 
   /**
@@ -85,6 +92,7 @@ class CanadianSalesTax extends LocalTaxTypeBase {
           'default' => TRUE,
         ],
       ],
+      'registration' => 'tax_ca_gst_number',
     ]);
     $zones['bc'] = new TaxZone([
       'id' => 'bc',
@@ -102,6 +110,7 @@ class CanadianSalesTax extends LocalTaxTypeBase {
           ],
         ],
       ],
+      'registration' => 'tax_ca_pst_bc_number',
     ]);
     $zones['mb'] = new TaxZone([
       'id' => 'mb',
@@ -119,6 +128,7 @@ class CanadianSalesTax extends LocalTaxTypeBase {
           ],
         ],
       ],
+      'registration' => 'tax_ca_pst_mb_number',
     ]);
     $zones['nb'] = new TaxZone([
       'id' => 'nb',
@@ -136,6 +146,7 @@ class CanadianSalesTax extends LocalTaxTypeBase {
           ],
         ],
       ],
+      'registration' => 'tax_ca_gst_number',
     ]);
     $zones['nl'] = new TaxZone([
       'id' => 'nl',
@@ -153,6 +164,7 @@ class CanadianSalesTax extends LocalTaxTypeBase {
           ],
         ],
       ],
+      'registration' => 'tax_ca_gst_number',
     ]);
     $zones['ns'] = new TaxZone([
       'id' => 'ns',
@@ -170,6 +182,7 @@ class CanadianSalesTax extends LocalTaxTypeBase {
           ],
         ],
       ],
+      'registration' => 'tax_ca_gst_number',
     ]);
     $zones['on'] = new TaxZone([
       'id' => 'on',
@@ -187,6 +200,7 @@ class CanadianSalesTax extends LocalTaxTypeBase {
           ],
         ],
       ],
+      'registration' => 'tax_ca_gst_number',
     ]);
     $zones['pe'] = new TaxZone([
       'id' => 'pe',
@@ -204,6 +218,7 @@ class CanadianSalesTax extends LocalTaxTypeBase {
           ],
         ],
       ],
+      'registration' => 'tax_ca_gst_number',
     ]);
     $zones['qc'] = new TaxZone([
       'id' => 'qc',
@@ -221,9 +236,52 @@ class CanadianSalesTax extends LocalTaxTypeBase {
           ],
         ],
       ],
+      'registration' => 'tax_ca_qst_number',
     ]);
 
     return $zones;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function storeFields() {
+    $fields = [];
+
+    $fields['tax_ca_gst_number'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Canada GST/HST #'))
+      ->setDisplayOptions('form', [
+        'type' => 'textfield',
+        'weight' => 5,
+      ])
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+    $fields['tax_ca_pst_bc_number'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('British Columbia PST #'))
+      ->setDisplayOptions('form', [
+        'type' => 'textfield',
+        'weight' => 5,
+      ])
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+    $fields['tax_ca_pst_mb_number'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Manitoba PST #'))
+      ->setDisplayOptions('form', [
+        'type' => 'textfield',
+        'weight' => 5,
+      ])
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+    $fields['tax_ca_qst_number'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Quebec QST #'))
+      ->setDisplayOptions('form', [
+        'type' => 'textfield',
+        'weight' => 5,
+      ])
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+
+    return $fields;
   }
 
 }

--- a/modules/tax/src/Plugin/Commerce/TaxType/EuropeanUnionVat.php
+++ b/modules/tax/src/Plugin/Commerce/TaxType/EuropeanUnionVat.php
@@ -3,6 +3,7 @@
 namespace Drupal\commerce_tax\Plugin\Commerce\TaxType;
 
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\commerce_tax\TaxableType;
 use Drupal\commerce_tax\TaxZone;
 use Drupal\Core\Form\FormStateInterface;
@@ -33,7 +34,7 @@ class EuropeanUnionVat extends LocalTaxTypeBase {
   /**
    * {@inheritdoc}
    */
-  protected function resolveZones(OrderItemInterface $order_item, ProfileInterface $customer_profile) {
+  protected function resolveZones(OrderItemInterface $order_item, ProfileInterface $customer_profile, StoreInterface $store) {
     $zones = $this->getZones();
     $customer_address = $customer_profile->address->first();
     $customer_country = $customer_address->getCountryCode();

--- a/modules/tax/src/Plugin/Commerce/TaxType/TaxTypeBase.php
+++ b/modules/tax/src/Plugin/Commerce/TaxType/TaxTypeBase.php
@@ -261,4 +261,11 @@ abstract class TaxTypeBase extends PluginBase implements TaxTypeInterface, Conta
     return $this->storeProfiles[$store_id];
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function storeFields() {
+    return [];
+  }
+
 }

--- a/modules/tax/src/Plugin/Commerce/TaxType/TaxTypeInterface.php
+++ b/modules/tax/src/Plugin/Commerce/TaxType/TaxTypeInterface.php
@@ -62,4 +62,12 @@ interface TaxTypeInterface extends ConfigurablePluginInterface, PluginFormInterf
    */
   public function apply(OrderInterface $order);
 
+  /**
+   * Generate store fields specific to this tax type.
+   *
+   * @return array
+   *   An array of fields to add to the store entity type.
+   */
+   public function storeFields();
+
 }

--- a/modules/tax/src/Plugin/Commerce/TaxType/TaxTypeInterface.php
+++ b/modules/tax/src/Plugin/Commerce/TaxType/TaxTypeInterface.php
@@ -68,6 +68,6 @@ interface TaxTypeInterface extends ConfigurablePluginInterface, PluginFormInterf
    * @return array
    *   An array of fields to add to the store entity type.
    */
-   public function storeFields();
+  public function storeFields();
 
 }

--- a/modules/tax/src/TaxZone.php
+++ b/modules/tax/src/TaxZone.php
@@ -4,6 +4,7 @@ namespace Drupal\commerce_tax;
 
 use CommerceGuys\Addressing\AddressInterface;
 use CommerceGuys\Addressing\Zone\ZoneTerritory;
+use Drupal\commerce_store\Entity\StoreInterface;
 
 /**
  * Represents a tax zone.
@@ -46,6 +47,13 @@ class TaxZone {
   protected $rates;
 
   /**
+   * Field on the Store holding registration data.
+   *
+   * @var string
+   */
+  protected $registration;
+
+  /**
    * Constructs a new TaxZone instance.
    *
    * @param array $definition
@@ -71,6 +79,9 @@ class TaxZone {
     }
     foreach ($definition['rates'] as $rate_definition) {
       $this->rates[] = new TaxRate($rate_definition);
+    }
+    if (isset($definition['registration'])) {
+      $this->registration = $definition['registration'];
     }
   }
 
@@ -142,6 +153,19 @@ class TaxZone {
       }
     }
     return FALSE;
+  }
+
+  /**
+   * Checks if the zone is registered if a registration field is specificed.
+   *
+   * @return bool
+   *   Whether the zone is registered.
+   */
+  public function isRegistered(StoreInterface $store) {
+    if (isset($this->registration)) {
+      return (bool) $store->get($this->registration)->value;
+    }
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
## Problem:
The multiple tax zones in the Canadian taxes (likely other areas), may not all be applicable since there are varying levels of registration requirements (sales volumes) and you may (for example) be registered to collect GST (also automatically HST), but not BC PST or MB PST or QST etc. However, it is currently all or nothing as to zones.

## Proposed Solution:
* Create registration fields per tax zone/type - this has an added benefit of being an easy way to provide data for receipts/invoices for jurisdictions that require tax numbers being present on invoices/receipts
* If present in tax zone definition, check for value on store as an extra registration confirmation.

To test, entity updates must be applied (drush entup). Only Canadian zones updated to use this - other zones will continue to work as previously.

## Todo:
Testing, documentation, update function(?).