### PR TITLE
Issue #2947227: Coupon access should not break if coupon is not attac…

### DIFF
--- a/modules/promotion/src/CouponAccessControlHandler.php
+++ b/modules/promotion/src/CouponAccessControlHandler.php
@@ -19,9 +19,9 @@ class CouponAccessControlHandler extends EntityAccessControlHandler {
     /** @var \Drupal\Core\Access\AccessResult $result */
     $result = parent::checkAccess($entity, $operation, $account);
 
-    if ($result->isNeutral()) {
+    if ($result->isNeutral() && $promotion = $entity->getPromotion()) {
       /** @var \Drupal\commerce_promotion\Entity\CouponInterface $entity */
-      $result = $entity->getPromotion()->access('update', $account, TRUE);
+      $result = $promotion->access('update', $account, TRUE);
     }
 
     return $result;


### PR DESCRIPTION
**Problem/Motivation**

Fatal error occur when trying to check access on a coupon which is not attached to a promotion.

**Proposed resolution**

Check coupon has promotion before using the access method of this promotion.


See https://www.drupal.org/project/commerce/issues/2947227