### PR TITLE
2980695 - i18n - Missing t() wrapper for string "Please Select

### DIFF
--- a/modules/product/src/Plugin/Field/FieldWidget/ProductVariationTitleWidget.php
+++ b/modules/product/src/Plugin/Field/FieldWidget/ProductVariationTitleWidget.php
@@ -27,7 +27,7 @@ class ProductVariationTitleWidget extends ProductVariationWidgetBase implements 
   public static function defaultSettings() {
     return [
       'label_display' => TRUE,
-      'label_text' => 'Please select',
+      'label_text' => t('Please select'),
     ] + parent::defaultSettings();
   }
 


### PR DESCRIPTION
Quick fix for a small issue on i18n, missing t() wrapper for a label element. See also:
https://www.drupal.org/project/commerce/issues/2980695