### PR TITLE
Issue #2987883: Error in recalculation in cas order item is referenced but no more exists

### DIFF
--- a/modules/order/src/Entity/Order.php
+++ b/modules/order/src/Entity/Order.php
@@ -379,7 +379,7 @@ class Order extends CommerceContentEntityBase implements OrderInterface {
         $adjustments = $adjustment_transformer->roundAdjustments($adjustments);
         foreach ($adjustments as $adjustment) {
           if (!$adjustment->isIncluded()) {
-            $total_price = $total_price->add($adjustment->getAmount());
+            $total_price = NULL !== $total_price ? $total_price->add($adjustment->getAmount()) : $adjustment->getAmount();
           }
         }
       }


### PR DESCRIPTION
See https://www.drupal.org/project/commerce/issues/2987883

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
In case (for some reasons), order item is deleted but order still has reference on it, recalculation will return an error:

```
Error: Call to a member function add() on null in Drupal\commerce_order\Entity\Order->recalculateTotalPrice() (line 373)
```

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
During adjustments loop, check total price is not null before adding amount.
If it's null, initiate value with the adjustment amount.
