### PR TITLE
Add 'checkout' route

### DIFF
--- a/modules/checkout/commerce_checkout.routing.yml
+++ b/modules/checkout/commerce_checkout.routing.yml
@@ -10,3 +10,12 @@ commerce_checkout.form:
     parameters:
       commerce_order:
         type: entity:commerce_order
+
+commerce_checkout.checkout:
+  path: '/checkout'
+  defaults:
+    _controller: '\Drupal\commerce_checkout\Controller\CheckoutController::checkoutRedirect'
+  requirements:
+    _access: 'TRUE'
+  options:
+    no_cache: TRUE


### PR DESCRIPTION
Feature request:
add /checkout route as a convenient, paramater-free way to redirect users to appropriate step of checkout

Use case:
I want to send a user to checkout, but don't know their cart id