### PR TITLE
Ensure order total price is not null

### DIFF
--- a/modules/payment/src/Plugin/Commerce/CheckoutPane/PaymentProcess.php
+++ b/modules/payment/src/Plugin/Commerce/CheckoutPane/PaymentProcess.php
@@ -129,7 +129,8 @@ class PaymentProcess extends CheckoutPaneBase {
    * {@inheritdoc}
    */
   public function isVisible() {
-    if ($this->order->getTotalPrice()->isZero()) {
+    $totalPrice = $this->order->getTotalPrice();
+    if (!$totalPrice || $totalPrice->isZero()) {
       // Hide the pane for free orders, since they don't need a payment.
       return FALSE;
     }


### PR DESCRIPTION
If the `OrderAvailabilityProcessor` removes an item due to some condition met in an `AvailabilityChecker` there is an edge case that the total price is `NULL` causing a fatal error.