### PR TITLE
Running tests against php7.2 throws errors attempting to count non-countable objects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ sudo: false
 dist: precise
 
 php:
+  - 7.2
   - 7.1
   - 7.0
 

--- a/modules/order/tests/src/Functional/OrderAdminTest.php
+++ b/modules/order/tests/src/Functional/OrderAdminTest.php
@@ -116,7 +116,7 @@ class OrderAdminTest extends OrderBrowserTestBase {
     $this->assertSession()->pageTextContains('The order has been successfully saved.');
 
     $this->drupalGet('/admin/commerce/orders');
-    $order_number = $this->getSession()->getPage()->find('css', 'tr td.views-field-order-number');
+    $order_number = $this->getSession()->getPage()->findAll('css', 'tr td.views-field-order-number');
     $this->assertEquals(1, count($order_number), 'Order exists in the table.');
 
     $order = Order::load(1);

--- a/modules/product/tests/src/Functional/ProductTypeTest.php
+++ b/modules/product/tests/src/Functional/ProductTypeTest.php
@@ -21,7 +21,7 @@ class ProductTypeTest extends ProductBrowserTestBase {
     $this->assertNotEmpty(!empty($product_type), 'The default product type is available.');
 
     $this->drupalGet('admin/commerce/config/product-types');
-    $rows = $this->getSession()->getPage()->find('css', 'table tbody tr');
+    $rows = $this->getSession()->getPage()->findAll('css', 'table tbody tr');
     $this->assertEquals(count($rows), 1, '1 product type is correctly listed.');
   }
 

--- a/modules/product/tests/src/Functional/ProductVariationTypeTest.php
+++ b/modules/product/tests/src/Functional/ProductVariationTypeTest.php
@@ -31,7 +31,7 @@ class ProductVariationTypeTest extends ProductBrowserTestBase {
     $this->assertNotEmpty(!empty($variation_type), 'The default product variation type is available.');
 
     $this->drupalGet('admin/commerce/config/product-variation-types');
-    $rows = $this->getSession()->getPage()->find('css', 'table tbody tr');
+    $rows = $this->getSession()->getPage()->findAll('css', 'table tbody tr');
     $this->assertEquals(count($rows), 1, '1 product variation type is correctly listed.');
   }
 

--- a/modules/promotion/tests/src/Functional/CouponTest.php
+++ b/modules/promotion/tests/src/Functional/CouponTest.php
@@ -76,7 +76,7 @@ class CouponTest extends CommerceBrowserTestBase {
     $this->getSession()->getPage()->fillField('code[0][value]', $code);
     $this->submitForm([], t('Save'));
     $this->assertSession()->pageTextContains("Saved the $code coupon.");
-    $coupon_count = $this->getSession()->getPage()->find('xpath', '//table/tbody/tr/td[text()="' . $code . '"]');
+    $coupon_count = $this->getSession()->getPage()->findAll('xpath', '//table/tbody/tr/td[text()="' . $code . '"]');
     $this->assertEquals(count($coupon_count), 1, 'Coupon exists in the table.');
 
     $coupon = Coupon::load(1);

--- a/modules/promotion/tests/src/FunctionalJavascript/PromotionTest.php
+++ b/modules/promotion/tests/src/FunctionalJavascript/PromotionTest.php
@@ -79,7 +79,7 @@ class PromotionTest extends CommerceBrowserTestBase {
 
     $this->submitForm([], t('Save'));
     $this->assertSession()->pageTextContains("Saved the $name promotion.");
-    $promotion_count = $this->getSession()->getPage()->find('xpath', '//table/tbody/tr/td[text()="' . $name . '"]');
+    $promotion_count = $this->getSession()->getPage()->findAll('xpath', '//table/tbody/tr/td[text()="' . $name . '"]');
     $this->assertEquals(count($promotion_count), 1, 'promotions exists in the table.');
 
     $promotion = Promotion::load(1);
@@ -123,7 +123,7 @@ class PromotionTest extends CommerceBrowserTestBase {
 
     $this->submitForm($edit, t('Save'));
     $this->assertSession()->pageTextContains("Saved the $name promotion.");
-    $promotion_count = $this->getSession()->getPage()->find('xpath', '//table/tbody/tr/td[text()="' . $name . '"]');
+    $promotion_count = $this->getSession()->getPage()->findAll('xpath', '//table/tbody/tr/td[text()="' . $name . '"]');
     $this->assertEquals(count($promotion_count), 1, 'promotions exists in the table.');
 
     /** @var \Drupal\commerce\Plugin\Field\FieldType\PluginItem $offer_field */

--- a/modules/store/tests/src/FunctionalJavascript/StoreTest.php
+++ b/modules/store/tests/src/FunctionalJavascript/StoreTest.php
@@ -68,7 +68,7 @@ class StoreTest extends CommerceBrowserTestBase {
     $this->submitForm($edit, t('Save'));
     $this->assertSession()->pageTextContains("Saved the $name store.");
     $store_count = $this->getSession()->getPage()->findAll('css', '.view-commerce-stores tr td.views-field-name');
-    $this->assertEquals(count($store_count), 1, 'Stores exists in the table.');
+    $this->assertEquals(2, count($store_count), 'Stores exists in the table.');
   }
 
   /**

--- a/modules/store/tests/src/FunctionalJavascript/StoreTest.php
+++ b/modules/store/tests/src/FunctionalJavascript/StoreTest.php
@@ -67,7 +67,7 @@ class StoreTest extends CommerceBrowserTestBase {
     }
     $this->submitForm($edit, t('Save'));
     $this->assertSession()->pageTextContains("Saved the $name store.");
-    $store_count = $this->getSession()->getPage()->find('css', '.view-commerce-stores tr td.views-field-name');
+    $store_count = $this->getSession()->getPage()->findAll('css', '.view-commerce-stores tr td.views-field-name');
     $this->assertEquals(count($store_count), 1, 'Stores exists in the table.');
   }
 


### PR DESCRIPTION
Testing the obvious fixes here. The tests appear to be trying to test that EXACTLY ONE thing exists, and while they passed prior to 7.2, they are actually testing the AT LEAST ONE thing exists, because find only returns the first found item, and count()ing a non-countable non-null object always returned 1.  Now testing a non-countable throws an error, so I switched the finds to findAll. The tests now test that EXACTLY ONE thing was found, so we will see if they need any updates due to the change.