### PR TITLE
Fix php notice "Undefined index: title"

### DIFF
--- a/commerce.install
+++ b/commerce.install
@@ -13,6 +13,7 @@ function commerce_requirements($phase) {
   if ($phase == 'install' || $phase == 'runtime') {
     if (!extension_loaded('bcmath')) {
       $requirements['commerce'] = [
+        'title' => t('BCMath'),
         'description' => t('Commerce requires the bcmath PHP extension.'),
         'severity' => REQUIREMENT_ERROR,
       ];


### PR DESCRIPTION
Drupal's core expecting to have `title` property in hook requirements, see https://github.com/drupal/drupal/blob/8.6.3/core/modules/system/src/SystemManager.php#L116, currently, there's PHP notice in the admin pages.