### PR TITLE
Issue #3016740: TaxOrderProcessor breaks the order item unit price override

### DIFF
--- a/modules/tax/src/TaxOrderProcessor.php
+++ b/modules/tax/src/TaxOrderProcessor.php
@@ -106,7 +106,7 @@ class TaxOrderProcessor implements OrderProcessorInterface {
             $tax_amount = $this->rounder->round($tax_amount);
             $unit_price = $unit_price->subtract($tax_amount);
           }
-          $order_item->setUnitPrice($unit_price);
+          $order_item->setUnitPrice($unit_price, $order_item->isUnitPriceOverridden());
         }
       }
     }

--- a/modules/tax/tests/src/Kernel/OrderIntegrationTest.php
+++ b/modules/tax/tests/src/Kernel/OrderIntegrationTest.php
@@ -153,8 +153,10 @@ class OrderIntegrationTest extends CommerceKernelTestBase {
       'type' => 'test',
       'quantity' => '1',
       'unit_price' => new Price('12.00', 'USD'),
+      'overridden_unit_price' => TRUE,
     ]);
     $order_item->save();
+    $this->assertTrue((bool) $order_item->isUnitPriceOverridden());
     $this->order->addItem($order_item);
     $this->order->setBillingProfile($profile);
     $this->order->save();
@@ -163,6 +165,7 @@ class OrderIntegrationTest extends CommerceKernelTestBase {
     $order_items = $this->order->getItems();
     $order_item = reset($order_items);
     $this->assertEquals(new Price('10.00', 'USD'), $order_item->getUnitPrice());
+    $this->assertTrue((bool) $order_item->isUnitPriceOverridden());
   }
 
 }


### PR DESCRIPTION
PR for https://www.drupal.org/project/commerce/issues/3016740.

