### PR TITLE
Add $form_state to ProductVariationAjaxChangeEvent (#3019102)

### DIFF
--- a/modules/product/src/Event/ProductVariationAjaxChangeEvent.php
+++ b/modules/product/src/Event/ProductVariationAjaxChangeEvent.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\commerce_product\Event;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Symfony\Component\EventDispatcher\Event;
@@ -35,6 +36,13 @@ class ProductVariationAjaxChangeEvent extends Event {
   protected $viewMode;
 
   /**
+   * The form state.
+   *
+   * @var \Drupal\Core\Form\FormStateInterface
+   */
+  protected $formState;
+
+  /**
    * Constructs a new ProductVariationAjaxChangeEvent.
    *
    * @param \Drupal\commerce_product\Entity\ProductVariationInterface $product_variation
@@ -44,10 +52,11 @@ class ProductVariationAjaxChangeEvent extends Event {
    * @param string $view_mode
    *   The view mode used to render the product variation.
    */
-  public function __construct(ProductVariationInterface $product_variation, AjaxResponse $response, $view_mode = 'default') {
+  public function __construct(ProductVariationInterface $product_variation, AjaxResponse $response, $view_mode = 'default', FormStateInterface $form_state) {
     $this->productVariation = $product_variation;
     $this->response = $response;
     $this->viewMode = $view_mode;
+    $this->formState = $form_state;
   }
 
   /**
@@ -80,4 +89,13 @@ class ProductVariationAjaxChangeEvent extends Event {
     return $this->viewMode;
   }
 
+  /**
+   * The view mode used to render the product variation.
+   *
+   * @return \Drupal\Core\Form\FormStateInterface
+   *   The form state.
+   */
+  public function getFormState() {
+    return $this->formState;
+  }
 }

--- a/modules/product/src/Plugin/Field/FieldWidget/ProductVariationWidgetBase.php
+++ b/modules/product/src/Plugin/Field/FieldWidget/ProductVariationWidgetBase.php
@@ -126,7 +126,7 @@ abstract class ProductVariationWidgetBase extends WidgetBase implements Containe
     $view_mode = $form_state->get('view_mode');
     $variation_field_renderer->replaceRenderedFields($response, $variation, $view_mode);
     // Allow modules to add arbitrary ajax commands to the response.
-    $event = new ProductVariationAjaxChangeEvent($variation, $response, $view_mode);
+    $event = new ProductVariationAjaxChangeEvent($variation, $response, $view_mode, $form_state);
     $event_dispatcher = \Drupal::service('event_dispatcher');
     $event_dispatcher->dispatch(ProductEvents::PRODUCT_VARIATION_AJAX_CHANGE, $event);
 


### PR DESCRIPTION
See [#3019102 issue on d.o](https://www.drupal.org/project/commerce/issues/3019102)

Add `$form_state` to the Ajax event so that developers can compare values of Variations against the  _Add To Cart_ form.

**How to test**

1. Create a custom module
2. Create a custom EventSubscriber
3. Subscribe to `ProductEvents::PRODUCT_VARIATION_AJAX_CHANGE`
4. Retrieve the `$form_state` with `$event->getFormState()`
5. Do your things... (e.g. get the Quantity `$qty = $form_state->getValue('quantity');` )

