### PR TITLE
Add separate render function to CheckoutProgressBlock

### DIFF
--- a/modules/checkout/src/Plugin/Block/CheckoutProgressBlock.php
+++ b/modules/checkout/src/Plugin/Block/CheckoutProgressBlock.php
@@ -3,6 +3,7 @@
 namespace Drupal\commerce_checkout\Plugin\Block;
 
 use Drupal\commerce_checkout\CheckoutOrderManagerInterface;
+use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -79,6 +80,18 @@ class CheckoutProgressBlock extends BlockBase implements ContainerFactoryPluginI
       // The block is being rendered outside of the checkout page.
       return [];
     }
+    
+    $requested_step_id = $this->routeMatch->getParameter('step');
+    return $this->render($order, $requested_step_id);
+  }
+
+  /**
+   * Builds the checkout progress block.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function render(OrderInterface $order, string $requested_step_id) {
     $checkout_flow = $this->checkoutOrderManager->getCheckoutFlow($order);
     $checkout_flow_plugin = $checkout_flow->getPlugin();
     $configuration = $checkout_flow_plugin->getConfiguration();
@@ -89,7 +102,6 @@ class CheckoutProgressBlock extends BlockBase implements ContainerFactoryPluginI
     // Prepare the steps as expected by the template.
     $steps = [];
     $visible_steps = $checkout_flow_plugin->getVisibleSteps();
-    $requested_step_id = $this->routeMatch->getParameter('step');
     $current_step_id = $this->checkoutOrderManager->getCheckoutStepId($order, $requested_step_id);
     $current_step_index = array_search($current_step_id, array_keys($visible_steps));
     $index = 0;

--- a/modules/checkout/src/Plugin/Block/CheckoutProgressBlock.php
+++ b/modules/checkout/src/Plugin/Block/CheckoutProgressBlock.php
@@ -3,6 +3,7 @@
 namespace Drupal\commerce_checkout\Plugin\Block;
 
 use Drupal\commerce_checkout\CheckoutOrderManagerInterface;
+use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -79,6 +80,17 @@ class CheckoutProgressBlock extends BlockBase implements ContainerFactoryPluginI
       // The block is being rendered outside of the checkout page.
       return [];
     }
+    
+    return $this->render($order);
+  }
+
+  /**
+   * Builds the checkout progress block.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function render(OrderInterface $order) {
     $checkout_flow = $this->checkoutOrderManager->getCheckoutFlow($order);
     $checkout_flow_plugin = $checkout_flow->getPlugin();
     $configuration = $checkout_flow_plugin->getConfiguration();

--- a/modules/checkout/src/Plugin/Commerce/CheckoutPane/ContactInformation.php
+++ b/modules/checkout/src/Plugin/Commerce/CheckoutPane/ContactInformation.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\commerce_checkout\Plugin\Commerce\CheckoutPane;
 
+use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -70,6 +71,9 @@ class ContactInformation extends CheckoutPaneBase implements CheckoutPaneInterfa
    * {@inheritdoc}
    */
   public function isVisible() {
+    if (!$this->order instanceof OrderInterface) {
+      return FALSE;
+    }    
     // Show the pane only for guest checkout.
     return empty($this->order->getCustomerId());
   }

--- a/modules/payment/src/Plugin/Commerce/CheckoutPane/PaymentProcess.php
+++ b/modules/payment/src/Plugin/Commerce/CheckoutPane/PaymentProcess.php
@@ -5,6 +5,7 @@ namespace Drupal\commerce_payment\Plugin\Commerce\CheckoutPane;
 use Drupal\commerce\InlineFormManager;
 use Drupal\commerce_checkout\Plugin\Commerce\CheckoutFlow\CheckoutFlowInterface;
 use Drupal\commerce_checkout\Plugin\Commerce\CheckoutPane\CheckoutPaneBase;
+use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_payment\Exception\DeclineException;
 use Drupal\commerce_payment\Exception\PaymentGatewayException;
 use Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\ManualPaymentGatewayInterface;
@@ -129,6 +130,9 @@ class PaymentProcess extends CheckoutPaneBase {
    * {@inheritdoc}
    */
   public function isVisible() {
+    if (!$this->order instanceof OrderInterface) {
+      return FALSE;
+    }    
     if ($this->order->isPaid() || $this->order->getTotalPrice()->isZero()) {
       // No payment is needed if the order is free or has already been paid.
       return FALSE;


### PR DESCRIPTION
**Problem/Motivation**

As a site builder, I would like to display the `CheckoutProgressBlock` on the Cart page (e.g `/cart`).

As of today, I can not do so. This block is restricted to `checkout` pages, where the `commerce_product` parameter is available. 

**Proposed solution**

To separate the rendering of the `CheckoutProgressBlock` in another function. Currenlty, everything is inside the `build()` method.

This way, as a developer, I can create a child block and render the `CheckoutProgressBlock` with my own logic.

**Example**

Here is an example of a child block which load the current Cart if the default `CheckoutProgressBlock` rendered nothing.

https://gist.github.com/MatthieuScarset/c29672ee99805d955988bc150bb642ab
